### PR TITLE
feat: implement GPU FFT & Multiexp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,11 @@ crossbeam = "0.7"
 byteorder = "1"
 ff = "0.4.0"
 paired = "0.15"
+ocl = { version = "0.19", optional = true }
+itertools = "0.8.0"
 
 [features]
-default = []
+default = ["ocl"]
 
 [package.metadata.release]
 pre-release-commit-message = "chore(release): release {{version}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ ocl = { version = "0.19", optional = true }
 itertools = "0.8.0"
 
 [features]
-default = ["ocl"]
+default = []
+gpu = ["ocl"]
 
 [package.metadata.release]
 pre-release-commit-message = "chore(release): release {{version}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ byteorder = "1"
 ff = "0.4.0"
 paired = "0.15"
 ocl = { version = "0.19", optional = true }
-itertools = "0.8.0"
+itertools = { version = "0.8.0", optional = true }
 
 [features]
 default = []
-gpu = ["ocl"]
+gpu = ["ocl", "itertools"]
 
 [package.metadata.release]
 pre-release-commit-message = "chore(release): release {{version}}"

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -17,6 +17,8 @@ use super::SynthesisError;
 
 use super::multicore::Worker;
 
+use gpu;
+
 pub struct EvaluationDomain<E: Engine, G: Group<E>> {
     coeffs: Vec<G>,
     exp: u32,
@@ -53,7 +55,6 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
                 return Err(SynthesisError::PolynomialDegreeTooLarge);
             }
         }
-
         // Compute omega, the 2^exp primitive root of unity
         let mut omega = E::Fr::root_of_unity();
         for _ in exp..E::Fr::S {
@@ -76,26 +77,30 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
         })
     }
 
-    pub fn fft(&mut self, worker: &Worker) {
-        best_fft(&mut self.coeffs, worker, &self.omega, self.exp);
+    pub fn fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E::Fr>>) {
+        best_fft(kern, &mut self.coeffs, worker, &self.omega, self.exp);
     }
 
-    pub fn ifft(&mut self, worker: &Worker) {
-        best_fft(&mut self.coeffs, worker, &self.omegainv, self.exp);
+    pub fn ifft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E::Fr>>) {
+        best_fft(kern, &mut self.coeffs, worker, &self.omegainv, self.exp);
 
-        worker
-            .scope(self.coeffs.len(), |scope, chunk| {
-                let minv = self.minv;
+        if let Some(ref mut k) = kern {
+            gpu_mul_by_field(k, &mut self.coeffs, &self.minv, self.exp).expect("GPU Multiply By Field failed!");
+        } else {
+            worker
+                .scope(self.coeffs.len(), |scope, chunk| {
+                    let minv = self.minv;
 
-                for v in self.coeffs.chunks_mut(chunk) {
-                    scope.spawn(move |_| {
-                        for v in v {
-                            v.group_mul_assign(&minv);
-                        }
-                    });
-                }
-            })
-            .unwrap();
+                    for v in self.coeffs.chunks_mut(chunk) {
+                        scope.spawn(move |_| {
+                            for v in v {
+                                v.group_mul_assign(&minv);
+                            }
+                        });
+                    }
+                })
+                .unwrap();
+        }
     }
 
     pub fn distribute_powers(&mut self, worker: &Worker, g: E::Fr) {
@@ -114,15 +119,15 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
             .unwrap();
     }
 
-    pub fn coset_fft(&mut self, worker: &Worker) {
+    pub fn coset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E::Fr>>) {
         self.distribute_powers(worker, E::Fr::multiplicative_generator());
-        self.fft(worker);
+        self.fft(worker, kern);
     }
 
-    pub fn icoset_fft(&mut self, worker: &Worker) {
+    pub fn icoset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E::Fr>>) {
         let geninv = self.geninv;
 
-        self.ifft(worker);
+        self.ifft(worker, kern);
         self.distribute_powers(worker, geninv);
     }
 
@@ -138,23 +143,27 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
     /// The target polynomial is the zero polynomial in our
     /// evaluation domain, so we must perform division over
     /// a coset.
-    pub fn divide_by_z_on_coset(&mut self, worker: &Worker) {
+    pub fn divide_by_z_on_coset(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E::Fr>>) {
         let i = self
             .z(&E::Fr::multiplicative_generator())
             .inverse()
             .unwrap();
 
-        worker
-            .scope(self.coeffs.len(), |scope, chunk| {
-                for v in self.coeffs.chunks_mut(chunk) {
-                    scope.spawn(move |_| {
-                        for v in v {
-                            v.group_mul_assign(&i);
-                        }
-                    });
-                }
-            })
-            .unwrap();
+        if let Some(ref mut k) = kern {
+            gpu_mul_by_field(k, &mut self.coeffs, &i, self.exp).expect("GPU Multiply By Field failed!");
+        } else {
+            worker
+                .scope(self.coeffs.len(), |scope, chunk| {
+                    for v in self.coeffs.chunks_mut(chunk) {
+                        scope.spawn(move |_| {
+                            for v in v {
+                                v.group_mul_assign(&i);
+                            }
+                        });
+                    }
+                })
+                .unwrap();
+        }
     }
 
     /// Perform O(n) multiplication of two polynomials in the domain.
@@ -269,17 +278,36 @@ impl<E: Engine> Group<E> for Scalar<E> {
     }
 }
 
-fn best_fft<E: Engine, T: Group<E>>(a: &mut [T], worker: &Worker, omega: &E::Fr, log_n: u32) {
-    let log_cpus = worker.log_num_cpus();
-
-    if log_n <= log_cpus {
-        serial_fft(a, omega, log_n);
+fn best_fft<E: Engine, T: Group<E>>(kern: &mut Option<gpu::FFTKernel<E::Fr>>, a: &mut [T], worker: &Worker, omega: &E::Fr, log_n: u32)
+{
+    if let Some(ref mut k) = kern {
+        gpu_fft(k, a, omega, log_n).expect("GPU FFT failed!");
     } else {
-        parallel_fft(a, worker, omega, log_n, log_cpus);
+        let log_cpus = worker.log_num_cpus();
+        if log_n <= log_cpus {
+            serial_fft(a, omega, log_n);
+        } else {
+            parallel_fft(a, worker, omega, log_n, log_cpus);
+        }
     }
 }
 
-fn serial_fft<E: Engine, T: Group<E>>(a: &mut [T], omega: &E::Fr, log_n: u32) {
+pub fn gpu_fft<E: Engine, T: Group<E>>(kern: &mut gpu::FFTKernel<E::Fr>, a: &mut [T], omega: &E::Fr, log_n: u32) -> gpu::GPUResult<()>
+{
+    let a = unsafe { std::mem::transmute::<&mut [T], &mut [E::Fr]>(a) };
+    kern.radix_fft(a, omega, log_n)?;
+    Ok(())
+}
+
+pub fn gpu_mul_by_field<E: Engine, T: Group<E>>(kern: &mut gpu::FFTKernel<E::Fr>, a: &mut [T], minv: &E::Fr, log_n: u32) -> gpu::GPUResult<()>
+{
+    let a = unsafe { std::mem::transmute::<&mut [T], &mut [E::Fr]>(a) };
+    kern.mul_by_field(a, minv, log_n)?;
+    Ok(())
+}
+
+pub fn serial_fft<E: Engine, T: Group<E>>(a: &mut [T], omega: &E::Fr, log_n: u32)
+{
     fn bitreverse(mut n: u32, l: u32) -> u32 {
         let mut r = 0;
         for _ in 0..l {
@@ -420,10 +448,10 @@ fn polynomial_arith() {
                 let mut a = EvaluationDomain::from_coeffs(a).unwrap();
                 let mut b = EvaluationDomain::from_coeffs(b).unwrap();
 
-                a.fft(&worker);
-                b.fft(&worker);
+                a.fft(&worker, &mut None);
+                b.fft(&worker, &mut None);
                 a.mul_assign(&worker, &b);
-                a.ifft(&worker);
+                a.ifft(&worker, &mut None);
 
                 for (naive, fft) in naive.iter().zip(a.coeffs.iter()) {
                     assert!(naive == fft);
@@ -454,17 +482,17 @@ fn fft_composition() {
             }
 
             let mut domain = EvaluationDomain::from_coeffs(v.clone()).unwrap();
-            domain.ifft(&worker);
-            domain.fft(&worker);
+            domain.ifft(&worker, &mut None);
+            domain.fft(&worker, &mut None);
             assert!(v == domain.coeffs);
-            domain.fft(&worker);
-            domain.ifft(&worker);
+            domain.fft(&worker, &mut None);
+            domain.ifft(&worker, &mut None);
             assert!(v == domain.coeffs);
-            domain.icoset_fft(&worker);
-            domain.coset_fft(&worker);
+            domain.icoset_fft(&worker, &mut None);
+            domain.coset_fft(&worker, &mut None);
             assert!(v == domain.coeffs);
-            domain.coset_fft(&worker);
-            domain.icoset_fft(&worker);
+            domain.coset_fft(&worker, &mut None);
+            domain.icoset_fft(&worker, &mut None);
             assert!(v == domain.coeffs);
         }
     }
@@ -506,4 +534,47 @@ fn parallel_fft_consistency() {
     let rng = &mut rand::thread_rng();
 
     test_consistency::<Bls12, _>(rng);
+}
+
+pub fn gpu_fft_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::FFTKernel<E::Fr>> where E: Engine {
+    let kern = gpu::FFTKernel::<E::Fr>::create(1 << log_d)?;
+    Ok(kern)
+}
+
+#[test]
+pub fn gpu_fft_consistency() {
+    use std::time::Instant;
+    use paired::bls12_381::{Bls12, Fr};
+    use rand::{Rand};
+    let rng = &mut rand::thread_rng();
+
+    let worker = Worker::new();
+    let log_cpus = worker.log_num_cpus();
+    let mut kern = gpu::FFTKernel::create(1 << 24).expect("Cannot initialize kernel!");
+
+    for log_d in 1..25 {
+        let d = 1 << log_d;
+
+        let elems = (0..d).map(|_| Scalar::<Bls12>(Fr::rand(rng))).collect::<Vec<_>>();
+        let mut v1 = EvaluationDomain::from_coeffs(elems.clone()).unwrap();
+        let mut v2 = EvaluationDomain::from_coeffs(elems.clone()).unwrap();
+
+        println!("Testing FFT for {} elements...", d);
+
+        let mut now = Instant::now();
+        gpu_fft(&mut kern, &mut v1.coeffs, &v1.omega, log_d).expect("GPU FFT failed!");
+        let gpu_dur = now.elapsed().as_secs() * 1000 as u64 + now.elapsed().subsec_millis() as u64;
+        println!("GPU took {}ms.", gpu_dur);
+
+        now = Instant::now();
+        if log_d <= log_cpus { serial_fft(&mut v2.coeffs, &v2.omega, log_d); }
+        else { parallel_fft(&mut v2.coeffs, &worker, &v2.omega, log_d, log_cpus); }
+        let cpu_dur = now.elapsed().as_secs() * 1000 as u64 + now.elapsed().subsec_millis() as u64;
+        println!("CPU ({} cores) took {}ms.", 1 << log_cpus, cpu_dur);
+
+        println!("Speedup: x{}", cpu_dur as f32 / gpu_dur as f32);
+
+        assert!(v1.coeffs == v2.coeffs);
+        println!("============================");
+    }
 }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -537,10 +537,21 @@ fn parallel_fft_consistency() {
 }
 
 pub fn gpu_fft_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::FFTKernel<E::Fr>> where E: Engine {
-    let kern = gpu::FFTKernel::<E::Fr>::create(1 << log_d)?;
-    Ok(kern)
+    const LOG_TEST_SIZE : u32 = 10;
+    const TEST_SIZE : u32 = 1 << LOG_TEST_SIZE;
+    use rand::Rand;
+    let rng = &mut rand::thread_rng();
+    let mut kern = gpu::FFTKernel::create(TEST_SIZE)?;
+    let elems = (0..TEST_SIZE).map(|_| Scalar::<E>(E::Fr::rand(rng))).collect::<Vec<_>>();
+    let mut v1 = EvaluationDomain::from_coeffs(elems.clone()).unwrap();
+    let mut v2 = EvaluationDomain::from_coeffs(elems.clone()).unwrap();
+    gpu_fft(&mut kern, &mut v1.coeffs, &v1.omega, LOG_TEST_SIZE)?;
+    serial_fft(&mut v2.coeffs, &v2.omega, LOG_TEST_SIZE);
+    if v1.coeffs == v2.coeffs { Ok(gpu::FFTKernel::create(1 << log_d)?) }
+    else { Err(gpu::GPUError {msg: "GPU FFT not supported!".to_string()} ) }
 }
 
+#[cfg(feature = "gpu")]
 #[test]
 pub fn gpu_fft_consistency() {
     use std::time::Instant;

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -545,8 +545,8 @@ fn parallel_fft_consistency() {
 }
 
 pub fn gpu_fft_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::FFTKernel<E::Fr>> where E: Engine {
-    const LOG_TEST_SIZE : u32 = 10;
-    const TEST_SIZE : u32 = 1 << LOG_TEST_SIZE;
+    let LOG_TEST_SIZE : u32 = std::cmp::min(E::Fr::S - 1, 10);
+    let TEST_SIZE : u32 = 1 << LOG_TEST_SIZE;
     use rand::Rand;
     let rng = &mut rand::thread_rng();
     let mut kern = gpu::FFTKernel::create(TEST_SIZE)?;

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -545,16 +545,16 @@ fn parallel_fft_consistency() {
 }
 
 pub fn gpu_fft_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::FFTKernel<E::Fr>> where E: Engine {
-    let LOG_TEST_SIZE : u32 = std::cmp::min(E::Fr::S - 1, 10);
-    let TEST_SIZE : u32 = 1 << LOG_TEST_SIZE;
+    let log_test_size : u32 = std::cmp::min(E::Fr::S - 1, 10);
+    let test_size : u32 = 1 << log_test_size;
     use rand::Rand;
     let rng = &mut rand::thread_rng();
-    let mut kern = gpu::FFTKernel::create(TEST_SIZE)?;
-    let elems = (0..TEST_SIZE).map(|_| Scalar::<E>(E::Fr::rand(rng))).collect::<Vec<_>>();
+    let mut kern = gpu::FFTKernel::create(test_size)?;
+    let elems = (0..test_size).map(|_| Scalar::<E>(E::Fr::rand(rng))).collect::<Vec<_>>();
     let mut v1 = EvaluationDomain::from_coeffs(elems.clone()).unwrap();
     let mut v2 = EvaluationDomain::from_coeffs(elems.clone()).unwrap();
-    gpu_fft(&mut kern, &mut v1.coeffs, &v1.omega, LOG_TEST_SIZE)?;
-    serial_fft(&mut v2.coeffs, &v2.omega, LOG_TEST_SIZE);
+    gpu_fft(&mut kern, &mut v1.coeffs, &v1.omega, log_test_size)?;
+    serial_fft(&mut v2.coeffs, &v2.omega, log_test_size);
     if v1.coeffs == v2.coeffs { Ok(gpu::FFTKernel::create(1 << log_d)?) }
     else { Err(gpu::GPUError {msg: "GPU FFT not supported!".to_string()} ) }
 }

--- a/src/gpu/common/defs.cl
+++ b/src/gpu/common/defs.cl
@@ -7,6 +7,7 @@ typedef ulong limb;
 
 #ifdef NVIDIA
 
+// Returns a * b + c + d, puts the carry in d
 limb mac_with_carry(limb a, limb b, limb c, limb *d) {
   limb lo, hi;
   asm("mad.lo.cc.u64 %0, %2, %3, %4;\r\n"
@@ -18,6 +19,7 @@ limb mac_with_carry(limb a, limb b, limb c, limb *d) {
   return lo;
 }
 
+// Returns a + b, puts the carry in d
 limb add_with_carry(limb a, limb *b) {
   limb lo, hi;
   asm("add.cc.u64 %0, %2, %3;\r\n"
@@ -27,6 +29,7 @@ limb add_with_carry(limb a, limb *b) {
   return lo;
 }
 
+// Returns a + b + c, puts the carry in c
 limb add2_with_carry(limb a, limb b, bool *c) {
   limb lo, hi, cc = *c;
   asm("add.cc.u64 %0, %2, %3;\r\n"

--- a/src/gpu/common/defs.cl
+++ b/src/gpu/common/defs.cl
@@ -1,0 +1,69 @@
+#ifdef __NV_CL_C_VERSION
+#define NVIDIA
+#endif
+
+typedef ulong limb;
+#define LIMB_BITS (64)
+
+#ifdef NVIDIA
+
+limb mac_with_carry(limb a, limb b, limb c, limb *d) {
+  limb lo, hi;
+  asm("mad.lo.cc.u64 %0, %2, %3, %4;\r\n"
+      "madc.hi.u64 %1, %2, %3, 0;\r\n"
+      "add.cc.u64 %0, %0, %5;\r\n"
+      "addc.u64 %1, %1, 0;\r\n"
+      : "=l"(lo), "=l"(hi) : "l"(a), "l"(b), "l"(c), "l"(*d));
+  *d = hi;
+  return lo;
+}
+
+limb add_with_carry(limb a, limb *b) {
+  limb lo, hi;
+  asm("add.cc.u64 %0, %2, %3;\r\n"
+      "addc.u64 %1, 0, 0;\r\n"
+      : "=l"(lo), "=l"(hi) : "l"(a), "l"(*b));
+  *b = hi;
+  return lo;
+}
+
+limb add2_with_carry(limb a, limb b, bool *c) {
+  limb lo, hi, cc = *c;
+  asm("add.cc.u64 %0, %2, %3;\r\n"
+      "addc.u64 %1, 0, 0;\r\n"
+      "add.cc.u64 %0, %0, %4;\r\n"
+      "addc.u64 %1, %1, 0;\r\n"
+      : "=l"(lo), "=l"(hi) : "l"(a), "l"(b), "l"(cc));
+  *c = hi;
+  return lo;
+}
+
+#else
+
+limb mac_with_carry(limb a, limb b, limb c, limb *d) {
+  limb lo = a * b + c;
+  limb hi = mad_hi(a, b, (limb)(lo < c));
+  a = lo;
+  lo += *d;
+  hi += (lo < a);
+  *d = hi;
+  return lo;
+}
+
+limb add_with_carry(limb a, limb *b) {
+  limb lo = a + *b;
+  *b = lo < a;
+  return lo;
+}
+
+limb add2_with_carry(limb a, limb b, bool *c) {
+  limb lo = a + b;
+  limb hi = lo < a;
+  a = lo;
+  lo += *c;
+  hi += (lo < a);
+  *c = hi;
+  return lo;
+}
+
+#endif

--- a/src/gpu/common/defs.cl
+++ b/src/gpu/common/defs.cl
@@ -5,68 +5,62 @@
 typedef ulong limb;
 #define LIMB_BITS (64)
 
-#ifdef NVIDIA
-
 // Returns a * b + c + d, puts the carry in d
 limb mac_with_carry(limb a, limb b, limb c, limb *d) {
-  limb lo, hi;
-  asm("mad.lo.cc.u64 %0, %2, %3, %4;\r\n"
-      "madc.hi.u64 %1, %2, %3, 0;\r\n"
-      "add.cc.u64 %0, %0, %5;\r\n"
-      "addc.u64 %1, %1, 0;\r\n"
-      : "=l"(lo), "=l"(hi) : "l"(a), "l"(b), "l"(c), "l"(*d));
-  *d = hi;
-  return lo;
+  #ifdef NVIDIA
+    limb lo, hi;
+    asm("mad.lo.cc.u64 %0, %2, %3, %4;\r\n"
+        "madc.hi.u64 %1, %2, %3, 0;\r\n"
+        "add.cc.u64 %0, %0, %5;\r\n"
+        "addc.u64 %1, %1, 0;\r\n"
+        : "=l"(lo), "=l"(hi) : "l"(a), "l"(b), "l"(c), "l"(*d));
+    *d = hi;
+    return lo;
+  #else
+    limb lo = a * b + c;
+    limb hi = mad_hi(a, b, (limb)(lo < c));
+    a = lo;
+    lo += *d;
+    hi += (lo < a);
+    *d = hi;
+    return lo;
+  #endif
 }
 
 // Returns a + b, puts the carry in d
 limb add_with_carry(limb a, limb *b) {
-  limb lo, hi;
-  asm("add.cc.u64 %0, %2, %3;\r\n"
-      "addc.u64 %1, 0, 0;\r\n"
-      : "=l"(lo), "=l"(hi) : "l"(a), "l"(*b));
-  *b = hi;
-  return lo;
+  #ifdef NVIDIA
+    limb lo, hi;
+    asm("add.cc.u64 %0, %2, %3;\r\n"
+        "addc.u64 %1, 0, 0;\r\n"
+        : "=l"(lo), "=l"(hi) : "l"(a), "l"(*b));
+    *b = hi;
+    return lo;
+  #else
+    limb lo = a + *b;
+    *b = lo < a;
+    return lo;
+  #endif
 }
 
 // Returns a + b + c, puts the carry in c
 limb add2_with_carry(limb a, limb b, bool *c) {
-  limb lo, hi, cc = *c;
-  asm("add.cc.u64 %0, %2, %3;\r\n"
-      "addc.u64 %1, 0, 0;\r\n"
-      "add.cc.u64 %0, %0, %4;\r\n"
-      "addc.u64 %1, %1, 0;\r\n"
-      : "=l"(lo), "=l"(hi) : "l"(a), "l"(b), "l"(cc));
-  *c = hi;
-  return lo;
+  #ifdef NVIDIA
+    limb lo, hi, cc = *c;
+    asm("add.cc.u64 %0, %2, %3;\r\n"
+        "addc.u64 %1, 0, 0;\r\n"
+        "add.cc.u64 %0, %0, %4;\r\n"
+        "addc.u64 %1, %1, 0;\r\n"
+        : "=l"(lo), "=l"(hi) : "l"(a), "l"(b), "l"(cc));
+    *c = hi;
+    return lo;
+  #else
+    limb lo = a + b;
+    limb hi = lo < a;
+    a = lo;
+    lo += *c;
+    hi += (lo < a);
+    *c = hi;
+    return lo;
+  #endif
 }
-
-#else
-
-limb mac_with_carry(limb a, limb b, limb c, limb *d) {
-  limb lo = a * b + c;
-  limb hi = mad_hi(a, b, (limb)(lo < c));
-  a = lo;
-  lo += *d;
-  hi += (lo < a);
-  *d = hi;
-  return lo;
-}
-
-limb add_with_carry(limb a, limb *b) {
-  limb lo = a + *b;
-  *b = lo < a;
-  return lo;
-}
-
-limb add2_with_carry(limb a, limb b, bool *c) {
-  limb lo = a + b;
-  limb hi = lo < a;
-  a = lo;
-  lo += *c;
-  hi += (lo < a);
-  *c = hi;
-  return lo;
-}
-
-#endif

--- a/src/gpu/common/field.cl
+++ b/src/gpu/common/field.cl
@@ -44,8 +44,15 @@ FIELD FIELD_sub_(FIELD a, FIELD b) {
   return a;
 }
 
+/*
+ * Montgomery reduction
+ * Takes the result of a long multiplication (Which has twice the size of a FIELD)
+ * as input and reduces it to a FIELD.
+ * Learn more:
+ * https://en.wikipedia.org/wiki/Montgomery_modular_multiplication
+ * https://alicebob.cryptoland.net/understanding-the-montgomery-reduction-algorithm/
+ */
 FIELD FIELD_reduce(limb *limbs) {
-  // Montgomery reduction
   bool carry2 = 0;
   for(uchar i = 0; i < FIELD_LIMBS; i++) {
     limb u = FIELD_INV * limbs[i];
@@ -55,7 +62,7 @@ FIELD FIELD_reduce(limb *limbs) {
     limbs[i + FIELD_LIMBS] = add2_with_carry(limbs[i + FIELD_LIMBS], carry, &carry2);
   }
 
-  // Divide by R
+  // Divide by R (Or take the upper half of `limbs` array as the final result)
   FIELD result;
   for(uchar i = 0; i < FIELD_LIMBS; i++) result.val[i] = limbs[i+FIELD_LIMBS];
 
@@ -67,7 +74,9 @@ FIELD FIELD_reduce(limb *limbs) {
 
 // Modular multiplication
 FIELD FIELD_mul(FIELD a, FIELD b) {
+
   // Long multiplication
+  // https://en.wikipedia.org/wiki/Multiplication_algorithm#Long_multiplication
   limb res[FIELD_LIMBS * 2] = {0};
   for(uchar i = 0; i < FIELD_LIMBS; i++) {
     limb carry = 0;
@@ -76,6 +85,7 @@ FIELD FIELD_mul(FIELD a, FIELD b) {
     res[i + FIELD_LIMBS] = carry;
   }
 
+  // Result doesn't fit into a FIELD, so a Montgomery reduction is needed.
   return FIELD_reduce(res);
 }
 
@@ -93,8 +103,11 @@ FIELD FIELD_add(FIELD a, FIELD b) {
   return res;
 }
 
+// Squaring is a special case of multiplication which can be done ~1.5x faster.
+// https://stackoverflow.com/a/16388571/1348497
 FIELD FIELD_sqr(FIELD a) {
-  // Long multiplication
+
+  // Long multiplication (Diagonal elements are skipped)
   limb res[FIELD_LIMBS * 2] = {0};
   for(uchar i = 0; i < FIELD_LIMBS - 1; i++) {
     limb carry = 0;
@@ -103,11 +116,13 @@ FIELD FIELD_sqr(FIELD a) {
     res[i + FIELD_LIMBS] = carry;
   }
 
+  // Double the result
   res[FIELD_LIMBS * 2 - 1] = res[FIELD_LIMBS * 2 - 2] >> (LIMB_BITS - 1);
   for(uchar i = FIELD_LIMBS * 2 - 2; i > 1; i--)
     res[i] = (res[i] << 1) | (res[i - 1] >> (LIMB_BITS - 1));
   res[1] <<= 1;
 
+  // Process diagonal elements
   limb carry = 0;
   for(uchar i = 0; i < FIELD_LIMBS; i++) {
     res[i * 2] = mac_with_carry(a.val[i], a.val[i], res[i * 2], &carry);
@@ -117,6 +132,8 @@ FIELD FIELD_sqr(FIELD a) {
   return FIELD_reduce(res);
 }
 
+// Left-shift the limbs by one bit and subtract by modulus in case of overflow.
+// Faster version of FIELD_add(a, a)
 FIELD FIELD_double(FIELD a) {
   for(uchar i = FIELD_LIMBS - 1; i >= 1; i--)
     a.val[i] = (a.val[i] << 1) | (a.val[i - 1] >> (LIMB_BITS - 1));
@@ -125,7 +142,8 @@ FIELD FIELD_double(FIELD a) {
   return a;
 }
 
-// Modular exponentiation
+// Modular exponentiation (Exponentiation by Squaring)
+// https://en.wikipedia.org/wiki/Exponentiation_by_squaring
 FIELD FIELD_pow(FIELD base, uint exponent) {
   FIELD res = FIELD_ONE;
   while(exponent > 0) {
@@ -137,6 +155,8 @@ FIELD FIELD_pow(FIELD base, uint exponent) {
   return res;
 }
 
+
+// Store squares of the base in a lookup table for faster evaluation.
 FIELD FIELD_pow_lookup(__global FIELD *bases, uint exponent) {
   FIELD res = FIELD_ONE;
   uint i = 0;

--- a/src/gpu/common/field.cl
+++ b/src/gpu/common/field.cl
@@ -1,0 +1,150 @@
+// FinalityLabs - 2019
+// Arbitrary size prime-field arithmetic library (add, sub, mul, pow)
+
+typedef struct { limb val[FIELD_LIMBS]; } FIELD;
+
+// Greater than or equal
+bool FIELD_gte(FIELD a, FIELD b) {
+  for(char i = FIELD_LIMBS - 1; i >= 0; i--){
+    if(a.val[i] > b.val[i])
+      return true;
+    if(a.val[i] < b.val[i])
+      return false;
+  }
+  return true;
+}
+
+// Equals
+bool FIELD_eq(FIELD a, FIELD b) {
+  for(uchar i = 0; i < FIELD_LIMBS; i++)
+    if(a.val[i] != b.val[i])
+      return false;
+  return true;
+}
+
+// Normal addition
+FIELD FIELD_add_(FIELD a, FIELD b) {
+  bool carry = 0;
+  for(uchar i = 0; i < FIELD_LIMBS; i++) {
+    limb old = a.val[i];
+    a.val[i] += b.val[i] + carry;
+    carry = carry ? old >= a.val[i] : old > a.val[i];
+  }
+  return a;
+}
+
+// Normal subtraction
+FIELD FIELD_sub_(FIELD a, FIELD b) {
+  bool borrow = 0;
+  for(uchar i = 0; i < FIELD_LIMBS; i++) {
+    limb old = a.val[i];
+    a.val[i] -= b.val[i] + borrow;
+    borrow = borrow ? old <= a.val[i] : old < a.val[i];
+  }
+  return a;
+}
+
+FIELD FIELD_reduce(limb *limbs) {
+  // Montgomery reduction
+  bool carry2 = 0;
+  for(uchar i = 0; i < FIELD_LIMBS; i++) {
+    limb u = FIELD_INV * limbs[i];
+    limb carry = 0;
+    for(uchar j = 0; j < FIELD_LIMBS; j++)
+      limbs[i + j] = mac_with_carry(u, FIELD_P.val[j], limbs[i + j], &carry);
+    limbs[i + FIELD_LIMBS] = add2_with_carry(limbs[i + FIELD_LIMBS], carry, &carry2);
+  }
+
+  // Divide by R
+  FIELD result;
+  for(uchar i = 0; i < FIELD_LIMBS; i++) result.val[i] = limbs[i+FIELD_LIMBS];
+
+  if(FIELD_gte(result, FIELD_P))
+    result = FIELD_sub_(result, FIELD_P);
+
+  return result;
+}
+
+// Modular multiplication
+FIELD FIELD_mul(FIELD a, FIELD b) {
+  // Long multiplication
+  limb res[FIELD_LIMBS * 2] = {0};
+  for(uchar i = 0; i < FIELD_LIMBS; i++) {
+    limb carry = 0;
+    for(uchar j = 0; j < FIELD_LIMBS; j++)
+      res[i + j] = mac_with_carry(a.val[i], b.val[j], res[i + j], &carry);
+    res[i + FIELD_LIMBS] = carry;
+  }
+
+  return FIELD_reduce(res);
+}
+
+// Modular subtraction
+FIELD FIELD_sub(FIELD a, FIELD b) {
+  FIELD res = FIELD_sub_(a, b);
+  if(!FIELD_gte(a, b)) res = FIELD_add_(res, FIELD_P);
+  return res;
+}
+
+// Modular addition
+FIELD FIELD_add(FIELD a, FIELD b) {
+  FIELD res = FIELD_add_(a, b);
+  if(FIELD_gte(res, FIELD_P)) res = FIELD_sub_(res, FIELD_P);
+  return res;
+}
+
+FIELD FIELD_sqr(FIELD a) {
+  // Long multiplication
+  limb res[FIELD_LIMBS * 2] = {0};
+  for(uchar i = 0; i < FIELD_LIMBS - 1; i++) {
+    limb carry = 0;
+    for(uchar j = i + 1; j < FIELD_LIMBS; j++)
+      res[i + j] = mac_with_carry(a.val[i], a.val[j], res[i + j], &carry);
+    res[i + FIELD_LIMBS] = carry;
+  }
+
+  res[FIELD_LIMBS * 2 - 1] = res[FIELD_LIMBS * 2 - 2] >> (LIMB_BITS - 1);
+  for(uchar i = FIELD_LIMBS * 2 - 2; i > 1; i--)
+    res[i] = (res[i] << 1) | (res[i - 1] >> (LIMB_BITS - 1));
+  res[1] <<= 1;
+
+  limb carry = 0;
+  for(uchar i = 0; i < FIELD_LIMBS; i++) {
+    res[i * 2] = mac_with_carry(a.val[i], a.val[i], res[i * 2], &carry);
+    res[i * 2 + 1] = add_with_carry(res[i * 2 + 1], &carry);
+  }
+
+  return FIELD_reduce(res);
+}
+
+FIELD FIELD_double(FIELD a) {
+  for(uchar i = FIELD_LIMBS - 1; i >= 1; i--)
+    a.val[i] = (a.val[i] << 1) | (a.val[i - 1] >> (LIMB_BITS - 1));
+  a.val[0] <<= 1;
+  if(FIELD_gte(a, FIELD_P)) a = FIELD_sub_(a, FIELD_P);
+  return a;
+}
+
+// Modular exponentiation
+FIELD FIELD_pow(FIELD base, uint exponent) {
+  FIELD res = FIELD_ONE;
+  while(exponent > 0) {
+    if (exponent & 1)
+      res = FIELD_mul(res, base);
+    exponent = exponent >> 1;
+    base = FIELD_sqr(base);
+  }
+  return res;
+}
+
+FIELD FIELD_pow_lookup(__global FIELD *bases, uint exponent) {
+  FIELD res = FIELD_ONE;
+  uint i = 0;
+  while(exponent > 0) {
+    if (exponent & 1)
+      res = FIELD_mul(res, bases[i]);
+    exponent = exponent >> 1;
+    i++;
+  }
+  return res;
+}

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -1,0 +1,35 @@
+use std::error;
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct GPUError {
+    pub msg: String
+}
+
+pub type GPUResult<T> = std::result::Result<T, GPUError>;
+
+impl fmt::Display for GPUError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl error::Error for GPUError {
+    fn description(&self) -> &str {
+        self.msg.as_str()
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        None
+    }
+}
+
+#[cfg(feature = "ocl")]
+use ocl;
+
+#[cfg(feature = "ocl")]
+impl From<ocl::Error> for GPUError {
+    fn from(error: ocl::Error) -> Self {
+        GPUError {msg: error.to_string() }
+    }
+}

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -24,10 +24,10 @@ impl error::Error for GPUError {
     }
 }
 
-#[cfg(feature = "ocl")]
+#[cfg(feature = "gpu")]
 use ocl;
 
-#[cfg(feature = "ocl")]
+#[cfg(feature = "gpu")]
 impl From<ocl::Error> for GPUError {
     fn from(error: ocl::Error) -> Self {
         GPUError {msg: error.to_string() }

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -127,7 +127,7 @@ impl<F> FFTKernel<F> where F: PrimeField {
     /// Multiplies all of the elements in `a` by `field`
     /// * `lgn` - Specifies log2 of number of elements
     pub fn mul_by_field(&mut self, a: &mut [F], field: &F, lgn: u32) -> GPUResult<()> {
-        let n = 1 << lgn;
+        let n = 1u32 << lgn;
         let ta = unsafe { std::mem::transmute::<&mut [F], &mut [structs::PrimeFieldStruct::<F>]>(a) };
         let field = structs::PrimeFieldStruct::<F>(*field);
         self.fft_src_buffer.write(&*ta).enq()?;

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -1,0 +1,128 @@
+use ocl::{ProQue, Buffer, MemFlags};
+use std::cmp;
+use ff::PrimeField;
+use super::error::GPUResult;
+use super::sources;
+use super::structs;
+
+const LOG2_MAX_ELEMENTS : usize = 32; // At most 2^32 elements is supported.
+const MAX_RADIX_DEGREE : u32 = 8;
+const MAX_LOCAL_WORK_SIZE_DEGREE : u32 = 7;
+
+pub struct FFTKernel<F> where F: PrimeField {
+    proque: ProQue,
+    fft_src_buffer: Buffer<structs::PrimeFieldStruct<F>>,
+    fft_dst_buffer: Buffer<structs::PrimeFieldStruct<F>>,
+    fft_pq_buffer: Buffer<structs::PrimeFieldStruct<F>>,
+    fft_omg_buffer: Buffer<structs::PrimeFieldStruct<F>>
+}
+
+impl<F> FFTKernel<F> where F: PrimeField {
+
+    pub fn create(n: u32) -> GPUResult<FFTKernel::<F>> {
+        let src = sources::fft_kernel::<F>();
+        let pq = ProQue::builder().src(src).dims(n).build()?;
+        let srcbuff = Buffer::builder().queue(pq.queue().clone())
+            .flags(MemFlags::new().read_write()).len(n)
+            .build()?;
+        let dstbuff = Buffer::builder().queue(pq.queue().clone())
+            .flags(MemFlags::new().read_write()).len(n)
+            .build()?;
+        let pqbuff = Buffer::builder().queue(pq.queue().clone())
+            .flags(MemFlags::new().read_write()).len(1 << MAX_RADIX_DEGREE >> 1)
+            .build()?;
+        let omgbuff = Buffer::builder().queue(pq.queue().clone())
+            .flags(MemFlags::new().read_write()).len(LOG2_MAX_ELEMENTS)
+            .build()?;
+
+        Ok(FFTKernel {proque: pq,
+                      fft_src_buffer: srcbuff,
+                      fft_dst_buffer: dstbuff,
+                      fft_pq_buffer: pqbuff,
+                      fft_omg_buffer: omgbuff})
+    }
+
+    fn radix_fft_round(&mut self, lgn: u32, lgp: u32, deg: u32, max_deg: u32, in_src: bool) -> ocl::Result<()> {
+        let n = 1u32 << lgn;
+        let lwsd = cmp::min(deg - 1, MAX_LOCAL_WORK_SIZE_DEGREE);
+        let kernel = self.proque.kernel_builder("radix_fft")
+            .global_work_size([n >> deg << lwsd])
+            .local_work_size(1 << lwsd)
+            .arg(if in_src { &self.fft_src_buffer } else { &self.fft_dst_buffer })
+            .arg(if in_src { &self.fft_dst_buffer } else { &self.fft_src_buffer })
+            .arg(&self.fft_pq_buffer)
+            .arg(&self.fft_omg_buffer)
+            .arg_local::<structs::PrimeFieldStruct::<F>>(1 << deg)
+            .arg(n)
+            .arg(lgp)
+            .arg(deg)
+            .arg(max_deg)
+            .build()?;
+        unsafe { kernel.enq()?; }
+        Ok(())
+    }
+
+    fn setup_pq(&mut self, omega: &F, n: usize, max_deg: u32) -> ocl::Result<()>  {
+        let mut tpq = vec![structs::PrimeFieldStruct::<F>::default(); 1 << max_deg >> 1];
+        let pq = unsafe { std::mem::transmute::<&mut [structs::PrimeFieldStruct::<F>], &mut [F]>(&mut tpq) };
+        let tw = omega.pow([(n >> max_deg) as u64]);
+        pq[0] = F::one();
+        if max_deg > 1 {
+            pq[1] = tw;
+            for i in 2..(1 << max_deg >> 1) {
+                pq[i] = pq[i-1];
+                pq[i].mul_assign(&tw);
+            }
+        }
+        self.fft_pq_buffer.write(&tpq).enq()?;
+
+        let mut tom = vec![structs::PrimeFieldStruct::<F>::default(); 32];
+        let om = unsafe { std::mem::transmute::<&mut [structs::PrimeFieldStruct::<F>], &mut [F]>(&mut tom) };
+        om[0] = *omega;
+        for i in 1..LOG2_MAX_ELEMENTS { om[i] = om[i-1].pow([2u64]); }
+        self.fft_omg_buffer.write(&tom).enq()?;
+
+        Ok(())
+    }
+
+    pub fn radix_fft(&mut self, a: &mut [F], omega: &F, lgn: u32) -> GPUResult<()> {
+        let n = 1 << lgn;
+
+        let ta = unsafe { std::mem::transmute::<&mut [F], &mut [structs::PrimeFieldStruct::<F>]>(a) };
+
+        let max_deg = cmp::min(MAX_RADIX_DEGREE, lgn);
+        self.setup_pq(omega, n, max_deg)?;
+
+        self.fft_src_buffer.write(&*ta).enq()?;
+        let mut in_src = true;
+        let mut lgp = 0u32;
+        while lgp < lgn {
+            let deg = cmp::min(max_deg, lgn - lgp);
+            self.radix_fft_round(lgn, lgp, deg, max_deg, in_src)?;
+            lgp += deg;
+            in_src = !in_src;
+        }
+        if in_src { self.fft_src_buffer.read(ta).enq()?; }
+        else { self.fft_dst_buffer.read(ta).enq()?; }
+        self.proque.finish()?; // Wait for all commands in the queue (Including read command)
+
+        Ok(())
+    }
+
+    pub fn mul_by_field(&mut self, a: &mut [F], field: &F, lgn: u32) -> GPUResult<()> {
+        let n = 1 << lgn;
+        let ta = unsafe { std::mem::transmute::<&mut [F], &mut [structs::PrimeFieldStruct::<F>]>(a) };
+        let field = structs::PrimeFieldStruct::<F>(*field);
+        self.fft_src_buffer.write(&*ta).enq()?;
+        let kernel = self.proque.kernel_builder("mul_by_field")
+            .global_work_size([n])
+            .arg(&self.fft_src_buffer)
+            .arg(n)
+            .arg(field)
+            .build()?;
+        unsafe { kernel.enq()?; }
+        self.fft_src_buffer.read(ta).enq()?;
+        self.proque.finish()?;
+        Ok(())
+    }
+}

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -48,7 +48,7 @@ impl<F> FFTKernel<F> where F: PrimeField {
     /// * `lgn` - Specifies log2 of number of elements
     /// * `lgp` - Specifies log2 of `p`, (http://www.bealto.com/gpu-fft_group-1.html)
     /// * `deg` - 1=>radix2, 2=>radix4, 3=>radix8, ...
-    /// * `max_deg` - The precalculated
+    /// * `max_deg` - The precalculated values pq` and `omegas` are valid for radix degrees up to `max_deg`
     fn radix_fft_round(&mut self, lgn: u32, lgp: u32, deg: u32, max_deg: u32, in_src: bool) -> ocl::Result<()> {
         let n = 1u32 << lgn;
         let lwsd = cmp::min(deg - 1, MAX_LOCAL_WORK_SIZE_DEGREE);
@@ -98,7 +98,7 @@ impl<F> FFTKernel<F> where F: PrimeField {
     }
 
     /// Performs FFT on `a`
-    /// * `omega` -
+    /// * `omega` - Special value `omega` is used for FFT over finite-fields
     /// * `lgn` - Specifies log2 of number of elements
     pub fn radix_fft(&mut self, a: &mut [F], omega: &F, lgn: u32) -> GPUResult<()> {
         let n = 1 << lgn;

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -5,6 +5,8 @@ use super::error::GPUResult;
 use super::sources;
 use super::structs;
 
+// NOTE: Please read `structs.rs` for an explanation for unsafe transmutes of this code!
+
 const LOG2_MAX_ELEMENTS : usize = 32; // At most 2^32 elements is supported.
 const MAX_RADIX_DEGREE : u32 = 8; // Radix256
 const MAX_LOCAL_WORK_SIZE_DEGREE : u32 = 7; // 128
@@ -63,7 +65,7 @@ impl<F> FFTKernel<F> where F: PrimeField {
             .arg(deg)
             .arg(max_deg)
             .build()?;
-        unsafe { kernel.enq()?; }
+        unsafe { kernel.enq()?; } // Running a GPU kernel is unsafe!
         Ok(())
     }
 

--- a/src/gpu/fft/fft.cl
+++ b/src/gpu/fft/fft.cl
@@ -1,0 +1,78 @@
+uint bitreverse(uint n, uint bits) {
+  uint r = 0;
+  for(int i = 0; i < bits; i++) {
+    r = (r << 1) | (n & 1);
+    n >>= 1;
+  }
+  return r;
+}
+
+__kernel void radix_fft(__global FIELD* x,
+                        __global FIELD* y,
+                        __global FIELD* pq,
+                        __global FIELD* omegas,
+                        __local FIELD* u,
+                        uint n,
+                        uint lgp,
+                        uint deg, // 1=>radix2, 2=>radix4, 3=>radix8, ...
+                        uint max_deg)
+{
+  uint lid = get_local_id(0);
+  uint lsize = get_local_size(0);
+  uint index = get_group_id(0);
+  uint t = n >> deg;
+  uint p = 1 << lgp;
+  uint k = index & (p - 1);
+
+  x += index;
+  y += ((index - k) << deg) + k;
+
+  uint count = 1 << deg; // 2^deg
+  uint counth = count >> 1; // Half of count
+
+  uint counts = count / lsize * lid;
+  uint counte = counts + count / lsize;
+
+  //////// ~30% of total time
+  FIELD twiddle = FIELD_pow_lookup(omegas, (n >> lgp >> deg) * k);
+  ////////
+
+  //////// ~35% of total time
+  FIELD tmp = FIELD_pow(twiddle, counts);
+  for(uint i = counts; i < counte; i++) {
+    u[i] = FIELD_mul(tmp, x[i*t]);
+    tmp = FIELD_mul(tmp, twiddle);
+  }
+  barrier(CLK_LOCAL_MEM_FENCE);
+  ////////
+
+  //////// ~35% of total time
+  uint pqshift = max_deg - deg;
+  for(uint rnd = 0; rnd < deg; rnd++) {
+    uint bit = counth >> rnd;
+    for(uint i = counts >> 1; i < counte >> 1; i++) {
+      uint di = i & (bit - 1);
+      uint i0 = (i << 1) - di;
+      uint i1 = i0 + bit;
+      tmp = u[i0];
+      u[i0] = FIELD_add(u[i0], u[i1]);
+      u[i1] = FIELD_sub(tmp, u[i1]);
+      if(di != 0) u[i1] = FIELD_mul(pq[di << rnd << pqshift], u[i1]);
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+  ////////
+
+  for(uint i = counts >> 1; i < counte >> 1; i++) {
+    y[i*p] = u[bitreverse(i, deg)];
+    y[(i+counth)*p] = u[bitreverse(i + counth, deg)];
+  }
+}
+
+__kernel void mul_by_field(__global FIELD* elements,
+                        uint n,
+                        FIELD field) {
+  uint gid = get_global_id(0);
+  elements[gid] = FIELD_mul(elements[gid], field);
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,25 +1,27 @@
 mod error;
 pub use self::error::*;
 
+#[cfg(feature = "gpu")]
 mod sources;
+#[cfg(feature = "gpu")]
 pub use self::sources::*;
 
-#[cfg(feature = "ocl")]
+#[cfg(feature = "gpu")]
 mod structs;
-#[cfg(feature = "ocl")]
+#[cfg(feature = "gpu")]
 pub use self::structs::*;
 
-#[cfg(feature = "ocl")]
+#[cfg(feature = "gpu")]
 mod fft;
-#[cfg(feature = "ocl")]
+#[cfg(feature = "gpu")]
 pub use self::fft::*;
 
-#[cfg(feature = "ocl")]
+#[cfg(feature = "gpu")]
 mod multiexp;
-#[cfg(feature = "ocl")]
+#[cfg(feature = "gpu")]
 pub use self::multiexp::*;
 
-#[cfg(not (feature = "ocl"))]
+#[cfg(not (feature = "gpu"))]
 mod nogpu;
-#[cfg(not (feature = "ocl"))]
+#[cfg(not (feature = "gpu"))]
 pub use self::nogpu::*;

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,25 @@
+mod error;
+pub use self::error::*;
+
+mod sources;
+pub use self::sources::*;
+
+#[cfg(feature = "ocl")]
+mod structs;
+#[cfg(feature = "ocl")]
+pub use self::structs::*;
+
+#[cfg(feature = "ocl")]
+mod fft;
+#[cfg(feature = "ocl")]
+pub use self::fft::*;
+
+#[cfg(feature = "ocl")]
+mod multiexp;
+#[cfg(feature = "ocl")]
+pub use self::multiexp::*;
+
+#[cfg(not (feature = "ocl"))]
+mod nogpu;
+#[cfg(not (feature = "ocl"))]
+pub use self::nogpu::*;

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -1,0 +1,137 @@
+use ocl::{ProQue, Buffer, MemFlags};
+use paired::Engine;
+use std::sync::Arc;
+use ocl::prm::{Uchar};
+use ff::{PrimeField, ScalarEngine};
+use paired::{CurveAffine, CurveProjective};
+use super::error::{GPUResult, GPUError};
+use super::sources;
+use super::structs;
+
+// Best params for RTX 2080Ti
+const NUM_GROUPS : usize = 334;
+const WINDOW_SIZE : usize = 10;
+const NUM_WINDOWS : usize = 26;
+
+const LOCAL_WORK_SIZE : usize = 256;
+const BUCKET_LEN : usize = 1 << WINDOW_SIZE;
+
+pub struct MultiexpKernel<E> where E: Engine {
+    proque: ProQue,
+
+    g1_base_buffer: Buffer<structs::CurveAffineStruct<E::G1Affine>>,
+    g1_bucket_buffer: Buffer<structs::CurveProjectiveStruct<E::G1>>,
+    g1_result_buffer: Buffer<structs::CurveProjectiveStruct<E::G1>>,
+
+    g2_base_buffer: Buffer<structs::CurveAffineStruct<E::G2Affine>>,
+    g2_bucket_buffer: Buffer<structs::CurveProjectiveStruct<E::G2>>,
+    g2_result_buffer: Buffer<structs::CurveProjectiveStruct<E::G2>>,
+
+    exp_buffer: Buffer<structs::PrimeFieldStruct<E::Fr>>,
+    dm_buffer: Buffer<Uchar>
+}
+
+impl<E> MultiexpKernel<E> where E: Engine {
+
+    pub fn create(n: u32) -> GPUResult<MultiexpKernel<E>> {
+        let src = sources::multiexp_kernel::<E>();
+        let pq = ProQue::builder().src(src).dims(n).build()?;
+
+        let g1basebuff = Buffer::builder().queue(pq.queue().clone()).flags(MemFlags::new().read_write()).len(n).build()?;
+        let g1buckbuff = Buffer::builder().queue(pq.queue().clone()).flags(MemFlags::new().read_write()).len(BUCKET_LEN * NUM_WINDOWS * NUM_GROUPS).build()?;
+        let g1resbuff = Buffer::builder().queue(pq.queue().clone()).flags(MemFlags::new().read_write()).len(NUM_WINDOWS * NUM_GROUPS).build()?;
+
+        let g2basebuff = Buffer::builder().queue(pq.queue().clone()).flags(MemFlags::new().read_write()).len(n).build()?;
+        let g2buckbuff = Buffer::builder().queue(pq.queue().clone()).flags(MemFlags::new().read_write()).len(BUCKET_LEN * NUM_WINDOWS * NUM_GROUPS).build()?;
+        let g2resbuff = Buffer::builder().queue(pq.queue().clone()).flags(MemFlags::new().read_write()).len(NUM_WINDOWS * NUM_GROUPS).build()?;
+
+        let expbuff = Buffer::builder().queue(pq.queue().clone()).flags(MemFlags::new().read_write()).len(n).build()?;
+        let dmbuff = Buffer::builder().queue(pq.queue().clone()).flags(MemFlags::new().read_write()).len(n).build()?;
+
+        Ok(MultiexpKernel {proque: pq,
+            g1_base_buffer: g1basebuff, g1_bucket_buffer: g1buckbuff, g1_result_buffer: g1resbuff,
+            g2_base_buffer: g2basebuff, g2_bucket_buffer: g2buckbuff, g2_result_buffer: g2resbuff,
+            exp_buffer: expbuff, dm_buffer: dmbuff})
+    }
+
+    pub fn multiexp<G>(&mut self,
+            bases: Arc<Vec<G>>,
+            exps: Arc<Vec<<<G::Engine as ScalarEngine>::Fr as PrimeField>::Repr>>,
+            dm: Vec<bool>,
+            skip: usize)
+            -> GPUResult<(<G as CurveAffine>::Projective)>
+            where G: CurveAffine {
+
+        let exp_bits = std::mem::size_of::<E::Fr>() * 8;
+        let n = exps.len();
+
+        let mut res = [<G as CurveAffine>::Projective::zero(); NUM_WINDOWS * NUM_GROUPS];
+        let exps = unsafe { std::mem::transmute::<Arc<Vec<<<G::Engine as ScalarEngine>::Fr as PrimeField>::Repr>>,Arc<Vec<<E::Fr as PrimeField>::Repr>>>(exps) }.to_vec();
+        let texps = unsafe { std::mem::transmute::<&[<E::Fr as PrimeField>::Repr], &[structs::PrimeFieldStruct::<E::Fr>]>(&exps[..]) };
+        let tdm = unsafe { std::mem::transmute::<&[bool], &[Uchar]>(&dm[..]) };
+        self.exp_buffer.write(texps).enq()?;
+        self.dm_buffer.write(tdm).enq()?;
+
+        let mut gws = NUM_WINDOWS * NUM_GROUPS;
+        gws += (LOCAL_WORK_SIZE - (gws % LOCAL_WORK_SIZE)) % LOCAL_WORK_SIZE;
+
+        let sz = std::mem::size_of::<G>(); // Trick, used for dispatching between G1 and G2!
+        if sz == std::mem::size_of::<E::G1Affine>() {
+            let tbases = unsafe { std::mem::transmute::<&[G], &[structs::CurveAffineStruct<E::G1Affine>]>(&bases) };
+            self.g1_base_buffer.write(tbases).enq()?;
+            let kernel = self.proque.kernel_builder("G1_bellman_multiexp")
+                .global_work_size([gws])
+                .local_work_size([LOCAL_WORK_SIZE])
+                .arg(&self.g1_base_buffer)
+                .arg(&self.g1_bucket_buffer)
+                .arg(&self.g1_result_buffer)
+                .arg(&self.exp_buffer)
+                .arg(&self.dm_buffer)
+                .arg(skip as u32)
+                .arg(n as u32)
+                .arg(NUM_GROUPS as u32)
+                .arg(NUM_WINDOWS as u32)
+                .arg(WINDOW_SIZE as u32)
+                .build()?;
+            unsafe { kernel.enq()?; }
+            let tres = unsafe { std::mem::transmute::<&mut [<G as CurveAffine>::Projective], &mut [structs::CurveProjectiveStruct::<E::G1>]>(&mut res) };
+            self.g1_result_buffer.read(tres).enq()?;
+
+        } else if sz == std::mem::size_of::<E::G2Affine>() {
+            let tbases = unsafe { std::mem::transmute::<&[G], &[structs::CurveAffineStruct<E::G2Affine>]>(&bases) };
+            self.g2_base_buffer.write(tbases).enq()?;
+            let kernel = self.proque.kernel_builder("G2_bellman_multiexp")
+                .global_work_size([gws])
+                .local_work_size([LOCAL_WORK_SIZE])
+                .arg(&self.g2_base_buffer)
+                .arg(&self.g2_bucket_buffer)
+                .arg(&self.g2_result_buffer)
+                .arg(&self.exp_buffer)
+                .arg(&self.dm_buffer)
+                .arg(skip as u32)
+                .arg(n as u32)
+                .arg(NUM_GROUPS as u32)
+                .arg(NUM_WINDOWS as u32)
+                .arg(WINDOW_SIZE as u32)
+                .build()?;
+            unsafe { kernel.enq()?; }
+            let tres = unsafe { std::mem::transmute::<&mut [<G as CurveAffine>::Projective], &mut [structs::CurveProjectiveStruct::<E::G2>]>(&mut res) };
+            self.g2_result_buffer.read(tres).enq()?;
+        } else {
+            return Err(GPUError {msg: "Only E::G1 and E::G2 are supported!".to_string()} );
+        }
+
+        let mut acc = <G as CurveAffine>::Projective::zero();
+        let mut bits = 0;
+        for i in 0..NUM_WINDOWS {
+            let w = std::cmp::min(WINDOW_SIZE, exp_bits - bits);
+            for _ in 0..w { acc.double(); }
+            for g in 0..NUM_GROUPS {
+                acc.add_assign(&res[g * NUM_WINDOWS + i]);
+            }
+            bits += w;
+        }
+
+        Ok(acc)
+    }
+}

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -65,7 +65,7 @@ impl<E> MultiexpKernel<E> where E: Engine {
 
         let exp_bits = std::mem::size_of::<E::Fr>() * 8;
 
-        let mut res = [<G as CurveAffine>::Projective::zero(); NUM_WINDOWS * NUM_GROUPS];
+        let mut res = vec![<G as CurveAffine>::Projective::zero(); NUM_WINDOWS * NUM_GROUPS];
         let exps = unsafe { std::mem::transmute::<Arc<Vec<<<G::Engine as ScalarEngine>::Fr as PrimeField>::Repr>>,Arc<Vec<<E::Fr as PrimeField>::Repr>>>(exps) }.to_vec();
         let texps = unsafe { std::mem::transmute::<&[<E::Fr as PrimeField>::Repr], &[structs::PrimeFieldStruct::<E::Fr>]>(&exps[..]) };
         self.exp_buffer.write(texps).enq()?;

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -7,6 +7,8 @@ use super::error::{GPUResult, GPUError};
 use super::sources;
 use super::structs;
 
+// NOTE: Please read `structs.rs` for an explanation for unsafe transmutes of this code!
+
 // Best params for RTX 2080Ti
 const NUM_GROUPS : usize = 334; // Partition the bases into `NUM_GROUPS` groups
 const WINDOW_SIZE : usize = 10; // Exponents are 255bit long, divide exponents into `WINDOW_SIZE` bit windows

--- a/src/gpu/multiexp/ec.cl
+++ b/src/gpu/multiexp/ec.cl
@@ -1,0 +1,112 @@
+#define POINT_ZERO ((POINT_projective){FIELD_ZERO, FIELD_ONE, FIELD_ZERO})
+
+typedef struct {
+  FIELD x;
+  FIELD y;
+  bool inf;
+} POINT_affine;
+
+typedef struct {
+  FIELD x;
+  FIELD y;
+  FIELD z;
+} POINT_projective;
+
+POINT_projective POINT_double(POINT_projective inp) {
+  if(FIELD_eq(inp.z, FIELD_ZERO)) return inp;
+  FIELD a = FIELD_sqr(inp.x); // A = X1^2
+  FIELD b = FIELD_sqr(inp.y); // B = Y1^2
+  FIELD c = FIELD_sqr(b); // C = B^2
+
+  // D = 2*((X1+B)2-A-C)
+  FIELD d = FIELD_add(inp.x, b);
+  d = FIELD_sqr(d); d = FIELD_sub(FIELD_sub(d, a), c); d = FIELD_double(d);
+
+  FIELD e = FIELD_add(FIELD_double(a), a); // E = 3*A
+
+  FIELD f = FIELD_sqr(e);
+
+  inp.z = FIELD_mul(inp.y, inp.z); inp.z = FIELD_double(inp.z); // Z3 = 2*Y1*Z1
+  inp.x = FIELD_sub(FIELD_sub(f, d), d); // X3 = F-2*D
+
+  // Y3 = E*(D-X3)-8*C
+  c = FIELD_double(c); c = FIELD_double(c); c = FIELD_double(c);
+  inp.y = FIELD_sub(FIELD_mul(FIELD_sub(d, inp.x), e), c);
+
+  return inp;
+}
+
+POINT_projective POINT_add_mixed(POINT_projective a, POINT_affine b) {
+  if(b.inf) return a;
+
+  if(FIELD_eq(a.z, FIELD_ZERO)) {
+    a.x = b.x;
+    a.y = b.y;
+    a.z = FIELD_ONE;
+    return a;
+  }
+
+  FIELD z1z1 = FIELD_sqr(a.z);
+  FIELD u2 = FIELD_mul(b.x, z1z1);
+  FIELD s2 = FIELD_mul(FIELD_mul(b.y, a.z), z1z1);
+
+  if(FIELD_eq(a.x, u2) && FIELD_eq(b.y, s2))
+    return POINT_double(a);
+  else {
+    FIELD h = FIELD_sub(u2, a.x); // H = U2-X1
+    FIELD hh = FIELD_sqr(h); // HH = H^2
+    FIELD i = FIELD_double(hh); i = FIELD_double(i); // I = 4*HH
+    FIELD j = FIELD_mul(h, i); // J = H*I
+    FIELD r = FIELD_sub(s2, a.y); r = FIELD_double(r); // r = 2*(S2-Y1)
+    FIELD v = FIELD_mul(a.x, i);
+
+    POINT_projective ret;
+
+     // X3 = r^2 - J - 2*V
+    ret.x = FIELD_sub(FIELD_sub(FIELD_sqr(r), j), FIELD_double(v));
+
+     // Y3 = r*(V-X3)-2*Y1*J
+    j = FIELD_mul(a.y, j); j = FIELD_double(j);
+    ret.y = FIELD_sub(FIELD_mul(FIELD_sub(v, ret.x), r), j);
+
+    // Z3 = (Z1+H)^2-Z1Z1-HH
+    ret.z = FIELD_add(a.z, h); ret.z = FIELD_sub(FIELD_sub(FIELD_sqr(ret.z), z1z1), hh);
+    return ret;
+  }
+}
+
+POINT_projective POINT_add(POINT_projective a, POINT_projective b) {
+
+  if(FIELD_eq(a.z, FIELD_ZERO)) return b;
+  if(FIELD_eq(b.z, FIELD_ZERO)) return a;
+
+  FIELD z1z1 = FIELD_sqr(a.z); // Z1Z1 = Z1^2
+  FIELD z2z2 = FIELD_sqr(b.z); // Z2Z2 = Z2^2
+  FIELD u1 = FIELD_mul(a.x, z2z2); // U1 = X1*Z2Z2
+  FIELD u2 = FIELD_mul(b.x, z1z1); // U2 = X2*Z1Z1
+  FIELD s1 = FIELD_mul(FIELD_mul(a.y, b.z), z2z2); // S1 = Y1*Z2*Z2Z2
+  FIELD s2 = FIELD_mul(FIELD_mul(b.y, a.z), z1z1); // S2 = Y2*Z1*Z1Z1
+
+  if(FIELD_eq(u1, u2) && FIELD_eq(s1, s2))
+    return POINT_double(a);
+  else {
+    FIELD h = FIELD_sub(u2, u1); // H = U2-U1
+    FIELD i = FIELD_double(h); i = FIELD_sqr(i); // I = (2*H)^2
+    FIELD j = FIELD_mul(h, i); // J = H*I
+    FIELD r = FIELD_sub(s2, s1); r = FIELD_double(r); // r = 2*(S2-S1)
+    FIELD v = FIELD_mul(u1, i); // V = U1*I
+    a.x = FIELD_sub(FIELD_sub(FIELD_sub(FIELD_sqr(r), j), v), v); // X3 = r^2 - J - 2*V
+
+    // Y3 = r*(V - X3) - 2*S1*J
+    a.y = FIELD_mul(FIELD_sub(v, a.x), r);
+    s1 = FIELD_mul(s1, j); s1 = FIELD_double(s1); // S1 = S1 * J * 2
+    a.y = FIELD_sub(a.y, s1);
+
+    // Z3 = ((Z1+Z2)^2 - Z1Z1 - Z2Z2)*H
+    a.z = FIELD_add(a.z, b.z); a.z = FIELD_sqr(a.z);
+    a.z = FIELD_sub(FIELD_sub(a.z, z1z1), z2z2);
+    a.z = FIELD_mul(a.z, h);
+
+    return a;
+  }
+}

--- a/src/gpu/multiexp/ec.cl
+++ b/src/gpu/multiexp/ec.cl
@@ -1,3 +1,5 @@
+// Elliptic curve operations (Short Weierstrass Jacobian form)
+
 #define POINT_ZERO ((POINT_projective){FIELD_ZERO, FIELD_ONE, FIELD_ZERO})
 
 typedef struct {
@@ -12,6 +14,7 @@ typedef struct {
   FIELD z;
 } POINT_projective;
 
+// http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#doubling-dbl-2009-l
 POINT_projective POINT_double(POINT_projective inp) {
   if(FIELD_eq(inp.z, FIELD_ZERO)) return inp;
   FIELD a = FIELD_sqr(inp.x); // A = X1^2
@@ -36,6 +39,7 @@ POINT_projective POINT_double(POINT_projective inp) {
   return inp;
 }
 
+// http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-madd-2007-bl
 POINT_projective POINT_add_mixed(POINT_projective a, POINT_affine b) {
   if(b.inf) return a;
 
@@ -75,6 +79,7 @@ POINT_projective POINT_add_mixed(POINT_projective a, POINT_affine b) {
   }
 }
 
+// http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-add-2007-bl
 POINT_projective POINT_add(POINT_projective a, POINT_projective b) {
 
   if(FIELD_eq(a.z, FIELD_ZERO)) return b;

--- a/src/gpu/multiexp/exp.cl
+++ b/src/gpu/multiexp/exp.cl
@@ -2,10 +2,12 @@
 
 typedef struct { limb val[EXPONENT_LIMBS]; } EXPONENT;
 
+// Get `i`th bit (From most significant digit) of the exponent.
 bool EXPONENT_get_bit(EXPONENT l, uint i) {
   return (l.val[EXPONENT_LIMBS - 1 - i / LIMB_BITS] >> (LIMB_BITS - 1 - (i % LIMB_BITS))) & 1;
 }
 
+// Get `window` consecutive bits, (Starting from `skip`th bit) from the exponent.
 uint EXPONENT_get_bits(EXPONENT l, uint skip, uint window) {
   uint ret = 0;
   for(uint i = 0; i < window; i++) {

--- a/src/gpu/multiexp/exp.cl
+++ b/src/gpu/multiexp/exp.cl
@@ -1,0 +1,16 @@
+#define EXPONENT_BITS (EXPONENT_LIMBS * LIMB_BITS)
+
+typedef struct { limb val[EXPONENT_LIMBS]; } EXPONENT;
+
+bool EXPONENT_get_bit(EXPONENT l, uint i) {
+  return (l.val[EXPONENT_LIMBS - 1 - i / LIMB_BITS] >> (LIMB_BITS - 1 - (i % LIMB_BITS))) & 1;
+}
+
+uint EXPONENT_get_bits(EXPONENT l, uint skip, uint window) {
+  uint ret = 0;
+  for(uint i = 0; i < window; i++) {
+    ret <<= 1;
+    ret |= EXPONENT_get_bit(l, skip + i);
+  }
+  return ret;
+}

--- a/src/gpu/multiexp/field2.cl
+++ b/src/gpu/multiexp/field2.cl
@@ -1,10 +1,12 @@
+// Fp2 Extension Field where u^2 + 1 = 0
+
 #define FIELD2_ZERO ((FIELD2){FIELD_ZERO, FIELD_ZERO})
 #define FIELD2_ONE ((FIELD2){FIELD_ONE, FIELD_ZERO})
 
 typedef struct {
   FIELD c0;
   FIELD c1;
-} FIELD2;
+} FIELD2; // Represents: c0 + u * c1
 
 bool FIELD2_eq(FIELD2 a, FIELD2 b) {
   return FIELD_eq(a.c0, b.c0) && FIELD_eq(a.c1, b.c1);
@@ -24,6 +26,13 @@ FIELD2 FIELD2_double(FIELD2 a) {
   a.c1 = FIELD_double(a.c1);
   return a;
 }
+
+/*
+ * (a_0 + u * a_1)(b_0 + u * b_1) = a_0 * b_0 - a_1 * b_1 + u * (a_0 * b_1 + a_1 * b_0)
+ * Therefore:
+ * c_0 = a_0 * b_0 - a_1 * b_1
+ * c_1 = (a_0 * b_1 + a_1 * b_0) = (a_0 + a_1) * (b_0 + b_1) - a_0 * b_0 - a_1 * b_1
+ */
 FIELD2 FIELD2_mul(FIELD2 a, FIELD2 b) {
   FIELD aa = FIELD_mul(a.c0, b.c0);
   FIELD bb = FIELD_mul(a.c1, b.c1);
@@ -35,6 +44,13 @@ FIELD2 FIELD2_mul(FIELD2 a, FIELD2 b) {
   a.c0 = FIELD_sub(aa, bb);
   return a;
 }
+
+/*
+ * (a_0 + u * a_1)(a_0 + u * a_1) = a_0 ^ 2 - a_1 ^ 2 + u * 2 * a_0 * a_1
+ * Therefore:
+ * c_0 = (a_0 * a_0 - a_1 * a_1) = (a_0 + a_1)(a_0 - a_1)
+ * c_1 = 2 * a_0 * a_1
+ */
 FIELD2 FIELD2_sqr(FIELD2 a) {
   FIELD ab = FIELD_mul(a.c0, a.c1);
   FIELD c0c1 = FIELD_add(a.c0, a.c1);

--- a/src/gpu/multiexp/field2.cl
+++ b/src/gpu/multiexp/field2.cl
@@ -1,0 +1,44 @@
+#define FIELD2_ZERO ((FIELD2){FIELD_ZERO, FIELD_ZERO})
+#define FIELD2_ONE ((FIELD2){FIELD_ONE, FIELD_ZERO})
+
+typedef struct {
+  FIELD c0;
+  FIELD c1;
+} FIELD2;
+
+bool FIELD2_eq(FIELD2 a, FIELD2 b) {
+  return FIELD_eq(a.c0, b.c0) && FIELD_eq(a.c1, b.c1);
+}
+FIELD2 FIELD2_sub(FIELD2 a, FIELD2 b) {
+  a.c0 = FIELD_sub(a.c0, b.c0);
+  a.c1 = FIELD_sub(a.c1, b.c1);
+  return a;
+}
+FIELD2 FIELD2_add(FIELD2 a, FIELD2 b) {
+  a.c0 = FIELD_add(a.c0, b.c0);
+  a.c1 = FIELD_add(a.c1, b.c1);
+  return a;
+}
+FIELD2 FIELD2_double(FIELD2 a) {
+  a.c0 = FIELD_double(a.c0);
+  a.c1 = FIELD_double(a.c1);
+  return a;
+}
+FIELD2 FIELD2_mul(FIELD2 a, FIELD2 b) {
+  FIELD aa = FIELD_mul(a.c0, b.c0);
+  FIELD bb = FIELD_mul(a.c1, b.c1);
+  FIELD o = FIELD_add(b.c0, b.c1);
+  a.c1 = FIELD_add(a.c1, a.c0);
+  a.c1 = FIELD_mul(a.c1, o);
+  a.c1 = FIELD_sub(a.c1, aa);
+  a.c1 = FIELD_sub(a.c1, bb);
+  a.c0 = FIELD_sub(aa, bb);
+  return a;
+}
+FIELD2 FIELD2_sqr(FIELD2 a) {
+  FIELD ab = FIELD_mul(a.c0, a.c1);
+  FIELD c0c1 = FIELD_add(a.c0, a.c1);
+  a.c0 = FIELD_mul(FIELD_sub(a.c0, a.c1), c0c1);
+  a.c1 = FIELD_double(ab);
+  return a;
+}

--- a/src/gpu/multiexp/multiexp.cl
+++ b/src/gpu/multiexp/multiexp.cl
@@ -1,4 +1,12 @@
-/* Bellman multiexp */
+/*
+ * Same multiexp algorithm used in Bellman, with some modifications.
+ * https://github.com/zkcrypto/bellman/blob/10c5010fd9c2ca69442dc9775ea271e286e776d8/src/multiexp.rs#L174
+ * The CPU version of multiexp parallelism is done by dividing the exponent
+ * values into smaller windows, and then applying a sequence of rounds to each
+ * window. The GPU kernel not only assigns a thread to each window but also
+ * divides the bases into several groups which highly increases the number of
+ * threads running in parallel for calculating a multiexp instance.
+ */
 
 __kernel void POINT_bellman_multiexp(
     __global POINT_affine *bases,
@@ -12,18 +20,27 @@ __kernel void POINT_bellman_multiexp(
     uint num_windows,
     uint window_size) {
 
+  // Bases are skipped by `self.1` elements, when converted from (Arc<Vec<G>>, usize) to Source
+  // https://github.com/zkcrypto/bellman/blob/10c5010fd9c2ca69442dc9775ea271e286e776d8/src/multiexp.rs#L38
+  bases += skip;
+
+  // We have `num_windows` * `num_groups` threads per multiexp.
   uint gid = get_global_id(0);
   if(gid > num_windows * num_groups) return;
 
+  // We have (2^window_size - 1) buckets.
   uint bucket_len = ((1 << window_size) - 1);
-  bases += skip;
+
+  // Each thread has its own set of buckets in global memory.
   buckets += bucket_len * gid;
   for(uint i = 0; i < bucket_len; i++) buckets[i] = POINT_ZERO;
 
-  uint len = (uint)ceil(n / (float)num_groups);
+  uint len = (uint)ceil(n / (float)num_groups); // Num of elements in each group
+
+  // This thread runs the multiexp algorithm on elements from `nstart` to `nened`
+  // on the window [`bits`, `bits` + `w`)
   uint nstart = len * (gid / num_windows);
   uint nend = min(nstart + len, n);
-
   uint bits = (gid % num_windows) * window_size;
   ushort w = min((ushort)window_size, (ushort)(EXPONENT_BITS - bits));
 
@@ -31,11 +48,19 @@ __kernel void POINT_bellman_multiexp(
   for(uint i = nstart; i < nend; i++) {
     if(dm[i]) {
       uint ind = EXPONENT_get_bits(exps[i], bits, w);
+
+      // Special case where it is faster to add the base into `res` instead of
+      // `bucket[0]`.
       if(ind == 1) res = POINT_add_mixed(res, bases[i]);
+
       else if(ind--) buckets[ind] = POINT_add_mixed(buckets[ind], bases[i]);
     }
   }
 
+  // Summation by parts
+  // e.g. 3a + 2b + 1c = a +
+  //                    (a) + b +
+  //                    ((a) + b) + c
   POINT_projective acc = POINT_ZERO;
   for(int j = bucket_len - 1; j >= 0; j--) {
     acc = POINT_add(acc, buckets[j]);

--- a/src/gpu/multiexp/multiexp.cl
+++ b/src/gpu/multiexp/multiexp.cl
@@ -1,0 +1,46 @@
+/* Bellman multiexp */
+
+__kernel void POINT_bellman_multiexp(
+    __global POINT_affine *bases,
+    __global POINT_projective *buckets,
+    __global POINT_projective *results,
+    __global EXPONENT *exps,
+    __global bool *dm,
+    uint skip,
+    uint n,
+    uint num_groups,
+    uint num_windows,
+    uint window_size) {
+
+  uint gid = get_global_id(0);
+  if(gid > num_windows * num_groups) return;
+
+  uint bucket_len = ((1 << window_size) - 1);
+  bases += skip;
+  buckets += bucket_len * gid;
+  for(uint i = 0; i < bucket_len; i++) buckets[i] = POINT_ZERO;
+
+  uint len = (uint)ceil(n / (float)num_groups);
+  uint nstart = len * (gid / num_windows);
+  uint nend = min(nstart + len, n);
+
+  uint bits = (gid % num_windows) * window_size;
+  ushort w = min((ushort)window_size, (ushort)(EXPONENT_BITS - bits));
+
+  POINT_projective res = POINT_ZERO;
+  for(uint i = nstart; i < nend; i++) {
+    if(dm[i]) {
+      uint ind = EXPONENT_get_bits(exps[i], bits, w);
+      if(ind == 1) res = POINT_add_mixed(res, bases[i]);
+      else if(ind--) buckets[ind] = POINT_add_mixed(buckets[ind], bases[i]);
+    }
+  }
+
+  POINT_projective acc = POINT_ZERO;
+  for(int j = bucket_len - 1; j >= 0; j--) {
+    acc = POINT_add(acc, buckets[j]);
+    res = POINT_add(res, acc);
+  }
+
+  results[gid] = res;
+}

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -1,0 +1,41 @@
+use ff::{PrimeField, ScalarEngine};
+use std::sync::Arc;
+use std::marker::PhantomData;
+use paired::{Engine, CurveAffine, CurveProjective};
+use super::error::{GPUResult, GPUError};
+
+pub struct FFTKernel<F>(PhantomData::<F>) where F: PrimeField;
+
+impl<F> FFTKernel<F> where F: PrimeField {
+
+    pub fn create(_: u32) -> GPUResult<FFTKernel::<F>> {
+        return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
+    }
+
+    pub fn radix_fft(&mut self, _: &mut [F], _: &F, _: u32) -> GPUResult<()> {
+        return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
+    }
+
+    pub fn mul_by_field(&mut self, _: &mut [F], _: &F, _: u32) -> GPUResult<()> {
+        return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
+    }
+}
+
+pub struct MultiexpKernel<E>(PhantomData::<E>) where E: Engine;
+
+impl<E> MultiexpKernel<E> where E: Engine {
+
+    pub fn create(_: u32) -> GPUResult<MultiexpKernel<E>> {
+        return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
+    }
+
+    pub fn multiexp<G>(&mut self,
+            _: Arc<Vec<G>>,
+            _: Arc<Vec<<<G::Engine as ScalarEngine>::Fr as PrimeField>::Repr>>,
+            _: Vec<bool>,
+            _: usize)
+            -> GPUResult<(<G as CurveAffine>::Projective)>
+            where G: CurveAffine {
+        return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
+    }
+}

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -1,7 +1,7 @@
 use ff::{PrimeField, ScalarEngine};
 use std::sync::Arc;
 use std::marker::PhantomData;
-use paired::{Engine, CurveAffine, CurveProjective};
+use paired::{Engine, CurveAffine};
 use super::error::{GPUResult, GPUError};
 
 // This module is compiled instead of `fft.rs` and `multiexp.rs` if `gpu` feature is disabled.
@@ -34,7 +34,7 @@ impl<E> MultiexpKernel<E> where E: Engine {
     pub fn multiexp<G>(&mut self,
             _: Arc<Vec<G>>,
             _: Arc<Vec<<<G::Engine as ScalarEngine>::Fr as PrimeField>::Repr>>,
-            _: Vec<bool>,
+            _: usize,
             _: usize)
             -> GPUResult<(<G as CurveAffine>::Projective)>
             where G: CurveAffine {

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -4,6 +4,8 @@ use std::marker::PhantomData;
 use paired::{Engine, CurveAffine, CurveProjective};
 use super::error::{GPUResult, GPUError};
 
+// This module is compiled instead of `fft.rs` and `multiexp.rs` if `gpu` feature is disabled.
+
 pub struct FFTKernel<F>(PhantomData::<F>) where F: PrimeField;
 
 impl<F> FFTKernel<F> where F: PrimeField {

--- a/src/gpu/sources.rs
+++ b/src/gpu/sources.rs
@@ -22,7 +22,7 @@ fn limbs_of<T>(value: &T) -> &[u64] {
     }
 }
 
-/// Calculate the `INV` parameter of Montomery reduction algorithm for 64bit limbs
+/// Calculate the `INV` parameter of Montgomery reduction algorithm for 64bit limbs
 /// * `a` - Is the first limb of modulus
 fn calc_inv(a: u64) -> u64 {
     let mut inv = 1u64;

--- a/src/gpu/sources.rs
+++ b/src/gpu/sources.rs
@@ -1,0 +1,89 @@
+use paired::Engine;
+use ff::PrimeField;
+use itertools::join;
+
+static DEFS_SRC : &str = include_str!("common/defs.cl");
+static FIELD_SRC : &str = include_str!("common/field.cl");
+static FFT_SRC : &str = include_str!("fft/fft.cl");
+
+static EXP_SRC : &str = include_str!("multiexp/exp.cl");
+static FIELD2_SRC : &str = include_str!("multiexp/field2.cl");
+static EC_SRC : &str = include_str!("multiexp/ec.cl");
+static MULTIEXP_SRC : &str = include_str!("multiexp/multiexp.cl");
+
+fn limbs_of<T>(value: &T) -> &[u64] {
+    unsafe {
+        std::slice::from_raw_parts(value as *const T as *const u64, std::mem::size_of::<T>() / 8)
+    }
+}
+
+fn calc_inv(a: u64) -> u64 {
+    let mut inv = 1u64;
+    for _ in 0..63 {
+        inv = inv.wrapping_mul(inv);
+        inv = inv.wrapping_mul(a);
+    }
+    return inv.wrapping_neg();
+}
+
+fn params<F>(name: &str) -> String where F: PrimeField {
+    let one = F::one(); let one = limbs_of(&one);
+    let p = F::char(); let p = limbs_of(&p);
+    let limbs = one.len();
+    let inv = calc_inv(p[0]);
+    let limbs_def = format!("#define {}_LIMBS {}", name, limbs);
+    let p_def = format!("#define {}_P (({}){{ {{ {} }} }})", name, name, join(p, ", "));
+    let one_def = format!("#define {}_ONE (({}){{ {{ {} }} }})", name, name, join(one, ", "));
+    let zero_def = format!("#define {}_ZERO (({}){{ {{ {} }} }})", name, name, join(vec![0u32; limbs], ", "));
+    let inv_def = format!("#define {}_INV {}", name, inv);
+    return format!("{}\n{}\n{}\n{}\n{}", limbs_def, one_def, p_def, zero_def, inv_def);
+}
+
+fn exponent<F>(name: &str) -> String where F: PrimeField {
+    return format!("{}\n{}\n",
+        format!("#define {}_LIMBS {}", name, limbs_of(&F::one()).len()),
+        String::from(EXP_SRC).replace("EXPONENT", name));
+}
+
+fn field<F>(name: &str) -> String where F: PrimeField {
+    return format!("{}\n{}\n",
+        params::<F>(name),
+        String::from(FIELD_SRC).replace("FIELD", name));
+}
+
+fn field2(field2: &str, field: &str) -> String {
+    return String::from(FIELD2_SRC)
+        .replace("FIELD2", field2)
+        .replace("FIELD", field);
+}
+
+fn fft(field: &str) -> String {
+    return String::from(FFT_SRC)
+        .replace("FIELD", field);
+}
+
+fn ec(field: &str, point: &str) -> String {
+    return String::from(EC_SRC)
+        .replace("FIELD", field)
+        .replace("POINT", point);
+}
+
+fn multiexp(point: &str, exp: &str) -> String {
+    return String::from(MULTIEXP_SRC)
+        .replace("POINT", point)
+        .replace("EXPONENT", exp);;
+}
+
+pub fn fft_kernel<F>() -> String where F: PrimeField {
+    return String::from(format!("{}\n{}\n{}",
+        DEFS_SRC,
+        field::<F>("Fr"), fft("Fr")));
+}
+
+pub fn multiexp_kernel<E>() -> String where E: Engine {
+    return String::from(format!("{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        DEFS_SRC,
+        exponent::<E::Fr>("Exp"),
+        field::<E::Fq>("Fq"), ec("Fq", "G1"), multiexp("G1", "Exp"),
+        field2("Fq2", "Fq"), ec("Fq2", "G2"), multiexp("G2", "Exp")));
+}

--- a/src/gpu/structs.rs
+++ b/src/gpu/structs.rs
@@ -1,0 +1,24 @@
+use paired::{CurveAffine, CurveProjective};
+use ff::{PrimeField};
+use ocl::traits::OclPrm;
+
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub struct PrimeFieldStruct<T>(pub T);
+impl<T> Default for PrimeFieldStruct<T> where T: PrimeField {
+    fn default() -> Self { PrimeFieldStruct::<T>(T::zero()) }
+}
+unsafe impl<T> OclPrm for PrimeFieldStruct<T> where T: PrimeField { }
+
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub struct CurveAffineStruct<T>(pub T);
+impl<T> Default for CurveAffineStruct<T> where T: CurveAffine {
+    fn default() -> Self { CurveAffineStruct::<T>(T::zero()) }
+}
+unsafe impl<T> OclPrm for CurveAffineStruct<T> where T: CurveAffine { }
+
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub struct CurveProjectiveStruct<T>(pub T);
+impl<T> Default for CurveProjectiveStruct<T> where T: CurveProjective {
+    fn default() -> Self { CurveProjectiveStruct::<T>(T::zero()) }
+}
+unsafe impl<T> OclPrm for CurveProjectiveStruct<T> where T: CurveProjective { }

--- a/src/gpu/structs.rs
+++ b/src/gpu/structs.rs
@@ -2,6 +2,9 @@ use paired::{CurveAffine, CurveProjective};
 use ff::{PrimeField};
 use ocl::traits::OclPrm;
 
+// Implement OclPrm trait for PrimeField, CurveAffine and CurveProjective
+// so that they can be copied to GPU.
+
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub struct PrimeFieldStruct<T>(pub T);
 impl<T> Default for PrimeFieldStruct<T> where T: PrimeField {

--- a/src/gpu/structs.rs
+++ b/src/gpu/structs.rs
@@ -11,6 +11,7 @@ use ocl::traits::OclPrm;
 // OpenCL friendly equivalents instead of mapping them to a new array with each element casted.
 
 #[derive(PartialEq, Debug, Clone, Copy)]
+#[repr(transparent)]
 pub struct PrimeFieldStruct<T>(pub T);
 impl<T> Default for PrimeFieldStruct<T> where T: PrimeField {
     fn default() -> Self { PrimeFieldStruct::<T>(T::zero()) }
@@ -18,6 +19,7 @@ impl<T> Default for PrimeFieldStruct<T> where T: PrimeField {
 unsafe impl<T> OclPrm for PrimeFieldStruct<T> where T: PrimeField { }
 
 #[derive(PartialEq, Debug, Clone, Copy)]
+#[repr(transparent)]
 pub struct CurveAffineStruct<T>(pub T);
 impl<T> Default for CurveAffineStruct<T> where T: CurveAffine {
     fn default() -> Self { CurveAffineStruct::<T>(T::zero()) }
@@ -25,6 +27,7 @@ impl<T> Default for CurveAffineStruct<T> where T: CurveAffine {
 unsafe impl<T> OclPrm for CurveAffineStruct<T> where T: CurveAffine { }
 
 #[derive(PartialEq, Debug, Clone, Copy)]
+#[repr(transparent)]
 pub struct CurveProjectiveStruct<T>(pub T);
 impl<T> Default for CurveProjectiveStruct<T> where T: CurveProjective {
     fn default() -> Self { CurveProjectiveStruct::<T>(T::zero()) }

--- a/src/gpu/structs.rs
+++ b/src/gpu/structs.rs
@@ -2,8 +2,13 @@ use paired::{CurveAffine, CurveProjective};
 use ff::{PrimeField};
 use ocl::traits::OclPrm;
 
-// Implement OclPrm trait for PrimeField, CurveAffine and CurveProjective
+// Everything that needs to be copied to GPU needs to implement OclPrm trait.
+// This module implements a generic OclPrm version of PrimeField, CurveAffine and CurveProjective
 // so that they can be copied to GPU.
+// A transmute from [PrimeField] to [PrimeFieldStruct] is safe as their sizes are equal.
+// Also safe for [CurveAffine] to [CurveAffineStruct] and [CurveProjective] to [CurveProjectiveStruct]
+// It costs less memory to just transmute the data sources for both FFT and Multiexp to their
+// OpenCL friendly equivalents instead of mapping them to a new array with each element casted.
 
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub struct PrimeFieldStruct<T>(pub T);

--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -274,7 +274,7 @@ where
     }
 
     // Use inverse FFT to convert powers of tau to Lagrange coefficients
-    powers_of_tau.ifft(&worker);
+    powers_of_tau.ifft(&worker, &mut None);
     let powers_of_tau = powers_of_tau.into_coeffs();
 
     let mut a = vec![E::G1::zero(); assembly.num_inputs + assembly.num_aux];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,9 @@ extern crate futures_cpupool;
 extern crate num_cpus;
 extern crate paired;
 extern crate rand;
-extern crate itertools;
 
+#[cfg(feature = "gpu")]
+extern crate itertools;
 #[cfg(feature = "gpu")]
 extern crate ocl;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate paired;
 extern crate rand;
 extern crate itertools;
 
-#[cfg(feature = "ocl")]
+#[cfg(feature = "gpu")]
 extern crate ocl;
 
 mod gpu;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,16 @@ extern crate futures_cpupool;
 extern crate num_cpus;
 extern crate paired;
 extern crate rand;
+extern crate itertools;
 
+#[cfg(feature = "ocl")]
+extern crate ocl;
+
+mod gpu;
 pub mod domain;
 pub mod groth16;
 pub mod multicore;
-mod multiexp;
+pub mod multiexp;
 
 use ff::Field;
 use paired::Engine;

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -6,6 +6,8 @@ use paired::{CurveAffine, CurveProjective};
 use std::io;
 use std::iter;
 use std::sync::Arc;
+use gpu;
+use paired::Engine;
 
 use super::SynthesisError;
 
@@ -14,6 +16,7 @@ pub trait SourceBuilder<G: CurveAffine>: Send + Sync + 'static + Clone {
     type Source: Source<G>;
 
     fn new(self) -> Self::Source;
+    fn get(self) -> (Arc<Vec<G>>, usize);
 }
 
 /// A source of bases, like an iterator.
@@ -34,6 +37,8 @@ impl<G: CurveAffine> SourceBuilder<G> for (Arc<Vec<G>>, usize) {
     fn new(self) -> (Arc<Vec<G>>, usize) {
         (self.0.clone(), self.1)
     }
+
+    fn get(self) -> (Arc<Vec<G>>, usize) { (self.0.clone(), self.1) }
 }
 
 impl<G: CurveAffine> Source<G> for (Arc<Vec<G>>, usize) {
@@ -256,13 +261,31 @@ pub fn multiexp<Q, D, G, S>(
     bases: S,
     density_map: D,
     exponents: Arc<Vec<<<G::Engine as ScalarEngine>::Fr as PrimeField>::Repr>>,
+    kern: &mut Option<gpu::MultiexpKernel<G::Engine>>
 ) -> Box<Future<Item = <G as CurveAffine>::Projective, Error = SynthesisError>>
 where
     for<'a> &'a Q: QueryDensity,
     D: Send + Sync + 'static + Clone + AsRef<Q>,
     G: CurveAffine,
-    S: SourceBuilder<G>,
+    S: SourceBuilder<G>
 {
+
+    if let Some(ref mut k) = kern {
+
+        // Extract the density map in an array
+        let mut dm = vec![false; exponents.len()];
+        let mut i = 0;
+        for (&_, d) in exponents.iter().zip(density_map.as_ref().iter()) {
+            dm[i] = d;
+            i += 1;
+        }
+
+        let (bss, skip) = bases.clone().get();
+        let result = k.multiexp(bss.clone(), exponents.clone(), dm, skip).expect("GPU Multiexp failed!");
+
+        return Box::new(pool.compute(move || { Ok(result) }))
+    }
+
     let c = if exponents.len() < 32 {
         3u32
     } else {
@@ -320,7 +343,60 @@ fn test_with_bls12() {
 
     let pool = Worker::new();
 
-    let fast = multiexp(&pool, (g, 0), FullDensity, v).wait().unwrap();
+    let fast = multiexp(&pool, (g, 0), FullDensity, v, &mut None).wait().unwrap();
 
     assert_eq!(naive, fast);
+}
+
+pub fn gpu_multiexp_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::MultiexpKernel<E>> where E: Engine {
+    let kern = gpu::MultiexpKernel::<E>::create(1 << log_d)?;
+    Ok(kern)
+}
+
+#[test]
+pub fn gpu_multiexp_consistency() {
+    use std::time::Instant;
+    use paired::bls12_381::Bls12;
+    use rand::{self, Rand};
+
+    const MAX_LOG_D: usize = 25;
+    const START_LOG_D: usize = 10;
+    let mut kern = gpu::MultiexpKernel::<Bls12>::create(1 << MAX_LOG_D).ok();
+    if kern.is_none() { panic!("Cannot initialize kernel!"); }
+    let pool = Worker::new();
+
+    let rng = &mut rand::thread_rng();
+
+    let mut bases =
+        (0..(1 << 10))
+            .map(|_| <Bls12 as Engine>::G1::rand(rng).into_affine())
+            .collect::<Vec<_>>();
+    for _ in 10..START_LOG_D { bases = [bases.clone(), bases.clone()].concat(); }
+
+    for log_d in START_LOG_D..(MAX_LOG_D + 1) {
+        let g = Arc::new(bases.clone());
+
+        let samples = 1 << log_d;
+        println!("Testing Multiexp for {} elements...", samples);
+
+        let v = Arc::new(
+            (0..samples)
+                .map(|_| <Bls12 as ScalarEngine>::Fr::rand(rng).into_repr())
+                .collect::<Vec<_>>(),
+        );
+
+        let mut avg = 0u64;
+        for i in 0..10 { // Get average of 10 timings
+            let now = Instant::now();
+            let gpu = multiexp(&pool, (g.clone(), 0), FullDensity, v.clone(), &mut kern).wait().unwrap();
+            let gpu_dur = now.elapsed().as_secs() * 1000 as u64 + now.elapsed().subsec_millis() as u64;
+            avg+=gpu_dur;
+            println!("GPU took {}ms.", gpu_dur);
+        }
+        println!("GPU took {}ms in average.", avg / 10);
+
+        println!("============================");
+
+        bases = [bases.clone(), bases.clone()].concat();
+    }
 }


### PR DESCRIPTION
This PR from @finalitylabs adds GPU accelerated versions of the Fast-Fourier-Transform and Multi-Exponentiation (For Bls12-381 engine) algorithms to the great Bellman library :) The `ocl` feature is turned on by default and can be disabled.
Let us know if any changes are needed before merging. @dignifiedquire

@nginnever, @keyvank