### PR TITLE
Fixed chunk-size for GPU Multiexp

### DIFF
--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -139,7 +139,7 @@ pub struct MultiexpKernel<E>(Vec<SingleMultiexpKernel<E>>) where E: Engine;
 
 impl<E> MultiexpKernel<E> where E: Engine {
 
-    pub fn create(n: u32) -> GPUResult<MultiexpKernel<E>> {
+    pub fn create() -> GPUResult<MultiexpKernel<E>> {
         let devices = utils::get_devices(utils::GPU_NVIDIA_PLATFORM_NAME)?;
         if devices.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
         let mut kernels = Vec::new();

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -16,7 +16,7 @@ use crossbeam::thread;
 const NUM_GROUPS : usize = 334; // Partition the bases into `NUM_GROUPS` groups
 const WINDOW_SIZE : usize = 10; // Exponents are 255bit long, divide exponents into `WINDOW_SIZE` bit windows
 const NUM_WINDOWS : usize = 26; // Then we will have Ceil(256/`WINDOW_SIZE`) windows per exponent
-const CHUNK_SIZE : usize = 30_000_000; // Maximum number of base elements we can pass to a GPU
+const CHUNK_SIZE : usize = 25_000_000; // Maximum number of base elements we can pass to a GPU
 // So each group will have `NUM_WINDOWS` threads and as there are `NUM_GROUPS` groups, there will
 // be `NUM_GROUPS` * `NUM_WINDOWS` threads in total.
 

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -16,6 +16,7 @@ use crossbeam::thread;
 const NUM_GROUPS : usize = 334; // Partition the bases into `NUM_GROUPS` groups
 const WINDOW_SIZE : usize = 10; // Exponents are 255bit long, divide exponents into `WINDOW_SIZE` bit windows
 const NUM_WINDOWS : usize = 26; // Then we will have Ceil(256/`WINDOW_SIZE`) windows per exponent
+const CHUNK_SIZE : usize = 30_000_000; // Maximum number of base elements we can pass to a GPU
 // So each group will have `NUM_WINDOWS` threads and as there are `NUM_GROUPS` groups, there will
 // be `NUM_GROUPS` * `NUM_WINDOWS` threads in total.
 
@@ -141,9 +142,8 @@ impl<E> MultiexpKernel<E> where E: Engine {
     pub fn create(n: u32) -> GPUResult<MultiexpKernel<E>> {
         let devices = utils::get_devices(utils::GPU_NVIDIA_PLATFORM_NAME)?;
         if devices.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
-        let chunk_size = ((n as f64) / (devices.len() as f64)).ceil() as u32;
         let mut kernels = Vec::new();
-        for dev in devices.into_iter().map(|device| { SingleMultiexpKernel::<E>::create(device, chunk_size) }) {
+        for dev in devices.into_iter().map(|device| { SingleMultiexpKernel::<E>::create(device, CHUNK_SIZE as u32) }) {
             kernels.push(dev?);
         }
         info!("Multiexp: {} working device(s) selected.", kernels.len());
@@ -170,7 +170,7 @@ impl<E> MultiexpKernel<E> where E: Engine {
         // Bases are skipped by `self.1` elements, when converted from (Arc<Vec<G>>, usize) to Source
         // https://github.com/zkcrypto/bellman/blob/10c5010fd9c2ca69442dc9775ea271e286e776d8/src/multiexp.rs#L38
         let bases = &bases[skip..];
-        
+
         let exps = &exps[..n];
 
         match thread::scope(|s| {
@@ -178,11 +178,16 @@ impl<E> MultiexpKernel<E> where E: Engine {
             let mut threads = Vec::new();
             for ((bases, exps), kern) in bases.chunks(chunk_size).zip(exps.chunks(chunk_size)).zip(self.0.iter_mut()) {
                 threads.push(s.spawn(move |s| {
-                    kern.multiexp(bases, exps, bases.len())
+                    let mut acc = <G as CurveAffine>::Projective::zero();
+                    for (bases, exps) in bases.chunks(CHUNK_SIZE).zip(exps.chunks(CHUNK_SIZE)) {
+                        let result = kern.multiexp(bases, exps, bases.len()).unwrap();
+                        acc.add_assign(&result);
+                    }
+                    acc
                 }));
             }
             for t in threads {
-                let result = t.join().unwrap().unwrap();
+                let result = t.join().unwrap();
                 acc.add_assign(&result);
             }
             acc

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -27,7 +27,7 @@ pub struct MultiexpKernel<E>(PhantomData::<E>) where E: Engine;
 
 impl<E> MultiexpKernel<E> where E: Engine {
 
-    pub fn create(_: u32) -> GPUResult<MultiexpKernel<E>> {
+    pub fn create() -> GPUResult<MultiexpKernel<E>> {
         return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
     }
 

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -212,11 +212,7 @@ where
 
     let mut log_d = 0u32; while (1 << log_d) < prover.a.len() { log_d += 1; }
 
-    let mut multiexp_kern = gpu_multiexp_supported::<E>(log_d).ok();
-    if multiexp_kern.is_some() { info!("GPU Multiexp is supported!"); }
-    else { info!("GPU Multiexp is NOT supported!"); }
-
-    let h = {
+    let a = {
         let mut fft_kern = gpu_fft_supported::<E>(log_d).ok();
         if fft_kern.is_some() { info!("GPU FFT is supported!"); }
         else { info!("GPU FFT is NOT supported!"); }
@@ -242,10 +238,14 @@ where
         let a_len = a.len() - 1;
         a.truncate(a_len);
         // TODO: parallelize if it's even helpful
-        let a = Arc::new(a.into_iter().map(|s| s.0.into_repr()).collect::<Vec<_>>());
-
-        multiexp(&worker, params.get_h(a.len())?, FullDensity, a, &mut multiexp_kern)
+        Arc::new(a.into_iter().map(|s| s.0.into_repr()).collect::<Vec<_>>())
     };
+
+    let mut multiexp_kern = gpu_multiexp_supported::<E>(log_d).ok();
+    if multiexp_kern.is_some() { info!("GPU Multiexp is supported!"); }
+    else { info!("GPU Multiexp is NOT supported!"); }
+
+    let h = multiexp(&worker, params.get_h(a.len())?, FullDensity, a, &mut multiexp_kern);
 
     // TODO: parallelize if it's even helpful
     let input_assignment = Arc::new(

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -351,7 +351,7 @@ pub fn gpu_multiexp_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::MultiexpKern
     use rand::Rand;
     let pool = Worker::new();
     let rng = &mut rand::thread_rng();
-    let mut kern = Some(gpu::MultiexpKernel::<E>::create(TEST_SIZE)?);
+    let mut kern = Some(gpu::MultiexpKernel::<E>::create()?);
     let bases_g1 = Arc::new((0..TEST_SIZE).map(|_| E::G1::rand(rng).into_affine()).collect::<Vec<_>>());
     let bases_g2 = Arc::new((0..TEST_SIZE).map(|_| E::G2::rand(rng).into_affine()).collect::<Vec<_>>());
     let exps = Arc::new((0..TEST_SIZE).map(|_| E::Fr::rand(rng).into_repr()).collect::<Vec<_>>());
@@ -359,7 +359,7 @@ pub fn gpu_multiexp_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::MultiexpKern
     let cpu_g1 = multiexp(&pool, (bases_g1.clone(), 0), FullDensity, exps.clone(), &mut None).wait().unwrap();
     let gpu_g2 = multiexp(&pool, (bases_g2.clone(), 0), FullDensity, exps.clone(), &mut kern).wait().unwrap();
     let cpu_g2 = multiexp(&pool, (bases_g2.clone(), 0), FullDensity, exps.clone(), &mut None).wait().unwrap();
-    if cpu_g1 == gpu_g1 && cpu_g2 == gpu_g2 { Ok(gpu::MultiexpKernel::<E>::create(1 << log_d)?) }
+    if cpu_g1 == gpu_g1 && cpu_g2 == gpu_g2 { Ok(kern.unwrap()) }
     else { Err(gpu::GPUError {msg: "GPU Multiexp not supported!".to_string()} ) }
 }
 
@@ -372,7 +372,7 @@ pub fn gpu_multiexp_consistency() {
 
     const MAX_LOG_D: usize = 20;
     const START_LOG_D: usize = 10;
-    let mut kern = gpu::MultiexpKernel::<Bls12>::create(1 << MAX_LOG_D).ok();
+    let mut kern = gpu::MultiexpKernel::<Bls12>::create().ok();
     if kern.is_none() { panic!("Cannot initialize kernel!"); }
     let pool = Worker::new();
 


### PR DESCRIPTION
This commit allows arbitrarily sized multiexp instances to run on multiple GPUs. Notice that the parameters are customized for 2080Ti cards and may not work properly on other cards.