### PR TITLE
Remove Zero-Knowledge part

### DIFF
--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -278,7 +278,6 @@ where
     let powers_of_tau = powers_of_tau.into_coeffs();
 
     let mut a = vec![E::G1::zero(); assembly.num_inputs + assembly.num_aux];
-    let mut b_g1 = vec![E::G1::zero(); assembly.num_inputs + assembly.num_aux];
     let mut b_g2 = vec![E::G2::zero(); assembly.num_inputs + assembly.num_aux];
     let mut ic = vec![E::G1::zero(); assembly.num_inputs];
     let mut l = vec![E::G1::zero(); assembly.num_aux];
@@ -298,7 +297,6 @@ where
 
         // Resulting evaluated QAP polynomials
         a: &mut [E::G1],
-        b_g1: &mut [E::G1],
         b_g2: &mut [E::G2],
         ext: &mut [E::G1],
 
@@ -316,16 +314,14 @@ where
         assert_eq!(a.len(), at.len());
         assert_eq!(a.len(), bt.len());
         assert_eq!(a.len(), ct.len());
-        assert_eq!(a.len(), b_g1.len());
         assert_eq!(a.len(), b_g2.len());
         assert_eq!(a.len(), ext.len());
 
         // Evaluate polynomials in multiple threads
         worker
             .scope(a.len(), |scope, chunk| {
-                for ((((((a, b_g1), b_g2), ext), at), bt), ct) in a
+                for (((((a, b_g2), ext), at), bt), ct) in a
                     .chunks_mut(chunk)
-                    .zip(b_g1.chunks_mut(chunk))
                     .zip(b_g2.chunks_mut(chunk))
                     .zip(ext.chunks_mut(chunk))
                     .zip(at.chunks(chunk))
@@ -336,9 +332,8 @@ where
                     let mut g2_wnaf = g2_wnaf.shared();
 
                     scope.spawn(move |_| {
-                        for ((((((a, b_g1), b_g2), ext), at), bt), ct) in a
+                        for (((((a, b_g2), ext), at), bt), ct) in a
                             .iter_mut()
-                            .zip(b_g1.iter_mut())
                             .zip(b_g2.iter_mut())
                             .zip(ext.iter_mut())
                             .zip(at.iter())
@@ -373,7 +368,6 @@ where
                             // Compute B query (in G1/G2)
                             if !bt.is_zero() {
                                 let bt_repr = bt.into_repr();
-                                *b_g1 = g1_wnaf.scalar(bt_repr);
                                 *b_g2 = g2_wnaf.scalar(bt_repr);
                             }
 
@@ -390,7 +384,6 @@ where
 
                         // Batch normalize
                         E::G1::batch_normalization(a);
-                        E::G1::batch_normalization(b_g1);
                         E::G2::batch_normalization(b_g2);
                         E::G1::batch_normalization(ext);
                     });
@@ -408,7 +401,6 @@ where
         &assembly.bt_inputs,
         &assembly.ct_inputs,
         &mut a[0..assembly.num_inputs],
-        &mut b_g1[0..assembly.num_inputs],
         &mut b_g2[0..assembly.num_inputs],
         &mut ic,
         &gamma_inverse,
@@ -426,7 +418,6 @@ where
         &assembly.bt_aux,
         &assembly.ct_aux,
         &mut a[assembly.num_inputs..],
-        &mut b_g1[assembly.num_inputs..],
         &mut b_g2[assembly.num_inputs..],
         &mut l,
         &delta_inverse,
@@ -464,12 +455,6 @@ where
         // Filter points at infinity away from A/B queries
         a: Arc::new(
             a.into_iter()
-                .filter(|e| !e.is_zero())
-                .map(|e| e.into_affine())
-                .collect(),
-        ),
-        b_g1: Arc::new(
-            b_g1.into_iter()
                 .filter(|e| !e.is_zero())
                 .map(|e| e.into_affine())
                 .collect(),

--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -482,7 +482,7 @@ mod test_with_bls12_381 {
             let mut v = vec![];
 
             params.write(&mut v).unwrap();
-            assert_eq!(v.len(), 2136);
+            assert_eq!(v.len(), 2036);
 
             let de_params = Parameters::read(&v[..], true).unwrap();
             assert!(params == de_params);

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -296,24 +296,6 @@ where
     let b_aux_density = Arc::new(prover.b_aux_density);
     let b_aux_density_total = b_aux_density.get_total_density();
 
-    let (b_g1_inputs_source, b_g1_aux_source) =
-        params.get_b_g1(b_input_density_total, b_aux_density_total)?;
-
-    let b_g1_inputs = multiexp(
-        &worker,
-        b_g1_inputs_source,
-        b_input_density.clone(),
-        input_assignment.clone(),
-        &mut multiexp_kern
-    );
-    let b_g1_aux = multiexp(
-        &worker,
-        b_g1_aux_source,
-        b_aux_density.clone(),
-        aux_assignment.clone(),
-        &mut multiexp_kern
-    );
-
     let (b_g2_inputs_source, b_g2_aux_source) =
         params.get_b_g2(b_input_density_total, b_aux_density_total)?;
 
@@ -332,33 +314,17 @@ where
         return Err(SynthesisError::UnexpectedIdentity);
     }
 
-    let mut g_a = vk.delta_g1.mul(r);
-    g_a.add_assign_mixed(&vk.alpha_g1);
-    let mut g_b = vk.delta_g2.mul(s);
-    g_b.add_assign_mixed(&vk.beta_g2);
-    let mut g_c;
-    {
-        let mut rs = r;
-        rs.mul_assign(&s);
-
-        g_c = vk.delta_g1.mul(rs);
-        g_c.add_assign(&vk.alpha_g1.mul(s));
-        g_c.add_assign(&vk.beta_g1.mul(r));
-    }
+    let mut g_a = vk.alpha_g1.into_projective();
+    let mut g_b = vk.beta_g2.into_projective();
+    let mut g_c = E::G1::zero();
     let mut a_answer = a_inputs.wait()?;
     a_answer.add_assign(&a_aux.wait()?);
     g_a.add_assign(&a_answer);
-    a_answer.mul_assign(s);
-    g_c.add_assign(&a_answer);
 
-    let mut b1_answer = b_g1_inputs.wait()?;
-    b1_answer.add_assign(&b_g1_aux.wait()?);
     let mut b2_answer = b_g2_inputs.wait()?;
     b2_answer.add_assign(&b_g2_aux.wait()?);
 
     g_b.add_assign(&b2_answer);
-    b1_answer.mul_assign(r);
-    g_c.add_assign(&b1_answer);
     g_c.add_assign(&h.wait()?);
     g_c.add_assign(&l.wait()?);
 

--- a/src/groth16/tests/mod.rs
+++ b/src/groth16/tests/mod.rs
@@ -182,7 +182,6 @@ fn test_xordemo() {
     assert_eq!(4, params.a.len());
 
     // The density of the B query is 2 (two variables are in at least one B term)
-    assert_eq!(2, params.b_g1.len());
     assert_eq!(2, params.b_g2.len());
 
     /*
@@ -228,14 +227,6 @@ fn test_xordemo() {
 
     for (u, a) in u_i.iter().zip(&params.a[..]) {
         assert_eq!(u, a);
-    }
-
-    for (v, b) in v_i
-        .iter()
-        .filter(|&&e| e != Fr::zero())
-        .zip(&params.b_g1[..])
-    {
-        assert_eq!(v, b);
     }
 
     for (v, b) in v_i

--- a/src/groth16/tests/mod.rs
+++ b/src/groth16/tests/mod.rs
@@ -290,9 +290,8 @@ fn test_xordemo() {
     //  a_3 * (5539*x^7 + 27797*x^6 + 6045*x^5 + 56449*x^4 + 58974*x^3 + 36716*x^2 + 58468*x + 8064) +
     {
         // proof A = alpha + A(tau) + delta * r
-        let mut expected_a = delta;
-        expected_a.mul_assign(&r);
-        expected_a.add_assign(&alpha);
+        // NOTE: delta * r is removed!
+        let mut expected_a = alpha;
         expected_a.add_assign(&u_i[0]); // a_0 = 1
         expected_a.add_assign(&u_i[1]); // a_1 = 1
         expected_a.add_assign(&u_i[2]); // a_2 = 1
@@ -307,9 +306,8 @@ fn test_xordemo() {
     // a_3 * (31177*x^7 + 44780*x^6 + 21752*x^5 + 42255*x^3 + 35861*x^2 + 33842*x + 48385)
     {
         // proof B = beta + B(tau) + delta * s
-        let mut expected_b = delta;
-        expected_b.mul_assign(&s);
-        expected_b.add_assign(&beta);
+        // NOTE: delta * s is removed!
+        let mut expected_b = beta;
         expected_b.add_assign(&v_i[0]); // a_0 = 1
         expected_b.add_assign(&v_i[1]); // a_1 = 1
         expected_b.add_assign(&v_i[2]); // a_2 = 1
@@ -332,22 +330,6 @@ fn test_xordemo() {
     //      = 49752*x^6 + 13914*x^5 + 29243*x^4 + 27227*x^3 + 62362*x^2 + 35703*x + 4032
     {
         let mut expected_c = Fr::zero();
-
-        // A * s
-        let mut tmp = proof.a;
-        tmp.mul_assign(&s);
-        expected_c.add_assign(&tmp);
-
-        // B * r
-        let mut tmp = proof.b;
-        tmp.mul_assign(&r);
-        expected_c.add_assign(&tmp);
-
-        // delta * r * s
-        let mut tmp = delta;
-        tmp.mul_assign(&r);
-        tmp.mul_assign(&s);
-        expected_c.sub_assign(&tmp);
 
         // L query answer
         // a_2 = 1, a_3 = 0


### PR DESCRIPTION
This commit removes the Zero-Knowledge part of the Groth16 protocol as proposed by @arielgabizon, introducing improvements in both proving-time and memory requirements of the protocol.

Please consult @arielgabizon for security considerations before merging!