### PR TITLE
feat(gpu): instantiates Bls12-381 devices once and share kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+parameters.dat

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 target
 Cargo.lock
-parameters.dat

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ lazy_static = { version = "1.4.0", optional = true }
 [features]
 default = []
 gpu = ["ocl", "itertools", "lazy_static"]
+gpu-test = ["gpu"]

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -77,11 +77,11 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
         })
     }
 
-    pub fn fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E::Fr>>) {
+    pub fn fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) {
         best_fft(kern, &mut self.coeffs, worker, &self.omega, self.exp);
     }
 
-    pub fn ifft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E::Fr>>) {
+    pub fn ifft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) {
         best_fft(kern, &mut self.coeffs, worker, &self.omegainv, self.exp);
 
         if let Some(ref mut k) = kern {
@@ -119,12 +119,12 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
             .unwrap();
     }
 
-    pub fn coset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E::Fr>>) {
+    pub fn coset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) {
         self.distribute_powers(worker, E::Fr::multiplicative_generator());
         self.fft(worker, kern);
     }
 
-    pub fn icoset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E::Fr>>) {
+    pub fn icoset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) {
         let geninv = self.geninv;
 
         self.ifft(worker, kern);
@@ -143,7 +143,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
     /// The target polynomial is the zero polynomial in our
     /// evaluation domain, so we must perform division over
     /// a coset.
-    pub fn divide_by_z_on_coset(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E::Fr>>) {
+    pub fn divide_by_z_on_coset(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) {
         let i = self
             .z(&E::Fr::multiplicative_generator())
             .inverse()
@@ -278,7 +278,7 @@ impl<E: Engine> Group<E> for Scalar<E> {
     }
 }
 
-fn best_fft<E: Engine, T: Group<E>>(kern: &mut Option<gpu::FFTKernel<E::Fr>>, a: &mut [T], worker: &Worker, omega: &E::Fr, log_n: u32)
+fn best_fft<E: Engine, T: Group<E>>(kern: &mut Option<gpu::FFTKernel<E>>, a: &mut [T], worker: &Worker, omega: &E::Fr, log_n: u32)
 {
     if let Some(ref mut k) = kern {
         gpu_fft(k, a, omega, log_n).expect("GPU FFT failed!");
@@ -292,7 +292,7 @@ fn best_fft<E: Engine, T: Group<E>>(kern: &mut Option<gpu::FFTKernel<E::Fr>>, a:
     }
 }
 
-pub fn gpu_fft<E: Engine, T: Group<E>>(kern: &mut gpu::FFTKernel<E::Fr>, a: &mut [T], omega: &E::Fr, log_n: u32) -> gpu::GPUResult<()>
+pub fn gpu_fft<E: Engine, T: Group<E>>(kern: &mut gpu::FFTKernel<E>, a: &mut [T], omega: &E::Fr, log_n: u32) -> gpu::GPUResult<()>
 {
     // EvaluationDomain module is supposed to work only with E::Fr elements, and not CurveProjective
     // points. The Bellman authors have implemented an unnecessarry abstraction called Group<E>
@@ -306,7 +306,7 @@ pub fn gpu_fft<E: Engine, T: Group<E>>(kern: &mut gpu::FFTKernel<E::Fr>, a: &mut
     Ok(())
 }
 
-pub fn gpu_mul_by_field<E: Engine, T: Group<E>>(kern: &mut gpu::FFTKernel<E::Fr>, a: &mut [T], minv: &E::Fr, log_n: u32) -> gpu::GPUResult<()>
+pub fn gpu_mul_by_field<E: Engine, T: Group<E>>(kern: &mut gpu::FFTKernel<E>, a: &mut [T], minv: &E::Fr, log_n: u32) -> gpu::GPUResult<()>
 {
     // The reason of unsafety is same as above.
     let a = unsafe { std::mem::transmute::<&mut [T], &mut [E::Fr]>(a) };
@@ -544,7 +544,7 @@ fn parallel_fft_consistency() {
     test_consistency::<Bls12, _>(rng);
 }
 
-pub fn gpu_fft_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::FFTKernel<E::Fr>> where E: Engine {
+pub fn gpu_fft_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::FFTKernel<E>> where E: Engine {
     let log_test_size : u32 = std::cmp::min(E::Fr::S - 1, 10);
     let test_size : u32 = 1 << log_test_size;
     use rand::Rand;

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -549,13 +549,13 @@ pub fn gpu_fft_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::FFTKernel<E::Fr>>
     let test_size : u32 = 1 << log_test_size;
     use rand::Rand;
     let rng = &mut rand::thread_rng();
-    let mut kern = gpu::FFTKernel::create(test_size)?;
+    let mut kern = gpu::FFTKernel::create(1 << log_d)?;
     let elems = (0..test_size).map(|_| Scalar::<E>(E::Fr::rand(rng))).collect::<Vec<_>>();
     let mut v1 = EvaluationDomain::from_coeffs(elems.clone()).unwrap();
     let mut v2 = EvaluationDomain::from_coeffs(elems.clone()).unwrap();
     gpu_fft(&mut kern, &mut v1.coeffs, &v1.omega, log_test_size)?;
     serial_fft(&mut v2.coeffs, &v2.omega, log_test_size);
-    if v1.coeffs == v2.coeffs { Ok(gpu::FFTKernel::create(1 << log_d)?) }
+    if v1.coeffs == v2.coeffs { Ok(kern) }
     else { Err(gpu::GPUError {msg: "GPU FFT not supported!".to_string()} ) }
 }
 

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -25,7 +25,7 @@ impl<F> FFTKernel<F> where F: PrimeField {
 
     pub fn create(n: u32) -> GPUResult<FFTKernel::<F>> {
         let src = sources::fft_kernel::<F>();
-        let devices = utils::get_devices(utils::GPU_NVIDIA_PLATFORM_NAME)?;
+        let devices = &utils::GPU_NVIDIA_DEVICES;
         if devices.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
         let device = devices[0]; // Select the first device for FFT
         let pq = ProQue::builder().device(device).src(src).dims(n).build()?;

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -4,7 +4,7 @@ use std::cmp;
 use ff::PrimeField;
 use super::error::{GPUResult, GPUError};
 use super::structs;
-use super::utils;
+use super::BLS12_KERNELS;
 
 // NOTE: Please read `structs.rs` for an explanation for unsafe transmutes of this code!
 
@@ -23,8 +23,8 @@ pub struct FFTKernel<F> where F: PrimeField {
 impl<F> FFTKernel<F> where F: PrimeField {
 
     pub fn create(n: u32) -> GPUResult<FFTKernel::<F>> {
-        if utils::BLS12_KERNELS.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
-        let pq = utils::BLS12_KERNELS[0].clone();
+        if BLS12_KERNELS.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
+        let pq = BLS12_KERNELS[0].clone();
         let srcbuff = Buffer::builder().queue(pq.queue().clone())
             .flags(MemFlags::new().read_write()).len(n)
             .build()?;

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -1,10 +1,12 @@
 use log::info;
 use ocl::{ProQue, Buffer, MemFlags};
 use std::cmp;
-use ff::PrimeField;
+use ff::Field;
+use paired::Engine;
 use super::error::{GPUResult, GPUError};
 use super::structs;
-use super::BLS12_KERNELS;
+use super::sources;
+use super::GPU_NVIDIA_DEVICES;
 
 // NOTE: Please read `structs.rs` for an explanation for unsafe transmutes of this code!
 
@@ -12,19 +14,23 @@ const LOG2_MAX_ELEMENTS : usize = 32; // At most 2^32 elements is supported.
 const MAX_RADIX_DEGREE : u32 = 8; // Radix256
 const MAX_LOCAL_WORK_SIZE_DEGREE : u32 = 7; // 128
 
-pub struct FFTKernel<F> where F: PrimeField {
+pub struct FFTKernel<E> where E: Engine {
     proque: ProQue,
-    fft_src_buffer: Buffer<structs::PrimeFieldStruct<F>>,
-    fft_dst_buffer: Buffer<structs::PrimeFieldStruct<F>>,
-    fft_pq_buffer: Buffer<structs::PrimeFieldStruct<F>>,
-    fft_omg_buffer: Buffer<structs::PrimeFieldStruct<F>>
+    fft_src_buffer: Buffer<structs::PrimeFieldStruct<E::Fr>>,
+    fft_dst_buffer: Buffer<structs::PrimeFieldStruct<E::Fr>>,
+    fft_pq_buffer: Buffer<structs::PrimeFieldStruct<E::Fr>>,
+    fft_omg_buffer: Buffer<structs::PrimeFieldStruct<E::Fr>>
 }
 
-impl<F> FFTKernel<F> where F: PrimeField {
+impl<E> FFTKernel<E> where E: Engine {
 
-    pub fn create(n: u32) -> GPUResult<FFTKernel::<F>> {
-        if BLS12_KERNELS.is_empty() { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
-        let pq = BLS12_KERNELS[0].clone();
+    pub fn create(n: u32) -> GPUResult<FFTKernel::<E>> {
+        let src = sources::kernel::<E>();
+        let devices = &GPU_NVIDIA_DEVICES;
+        if devices.is_empty() { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
+        let device = devices[0]; // Select the first device for FFT
+        let pq = ProQue::builder().device(device).src(src).dims(n).build()?;
+
         let srcbuff = Buffer::builder().queue(pq.queue().clone())
             .flags(MemFlags::new().read_write()).len(n)
             .build()?;
@@ -63,7 +69,7 @@ impl<F> FFTKernel<F> where F: PrimeField {
             .arg(if in_src { &self.fft_dst_buffer } else { &self.fft_src_buffer })
             .arg(&self.fft_pq_buffer)
             .arg(&self.fft_omg_buffer)
-            .arg_local::<structs::PrimeFieldStruct::<F>>(1 << deg)
+            .arg_local::<structs::PrimeFieldStruct::<E::Fr>>(1 << deg)
             .arg(n)
             .arg(lgp)
             .arg(deg)
@@ -74,14 +80,14 @@ impl<F> FFTKernel<F> where F: PrimeField {
     }
 
     /// Share some precalculated values between threads to boost the performance
-    fn setup_pq(&mut self, omega: &F, n: usize, max_deg: u32) -> ocl::Result<()>  {
+    fn setup_pq(&mut self, omega: &E::Fr, n: usize, max_deg: u32) -> ocl::Result<()>  {
 
         // Precalculate:
         // [omega^(0/(2^(deg-1))), omega^(1/(2^(deg-1))), ..., omega^((2^(deg-1)-1)/(2^(deg-1)))]
-        let mut tpq = vec![structs::PrimeFieldStruct::<F>::default(); 1 << max_deg >> 1];
-        let pq = unsafe { std::mem::transmute::<&mut [structs::PrimeFieldStruct::<F>], &mut [F]>(&mut tpq) };
+        let mut tpq = vec![structs::PrimeFieldStruct::<E::Fr>::default(); 1 << max_deg >> 1];
+        let pq = unsafe { std::mem::transmute::<&mut [structs::PrimeFieldStruct::<E::Fr>], &mut [E::Fr]>(&mut tpq) };
         let tw = omega.pow([(n >> max_deg) as u64]);
-        pq[0] = F::one();
+        pq[0] = E::Fr::one();
         if max_deg > 1 {
             pq[1] = tw;
             for i in 2..(1 << max_deg >> 1) {
@@ -92,8 +98,8 @@ impl<F> FFTKernel<F> where F: PrimeField {
         self.fft_pq_buffer.write(&tpq).enq()?;
 
         // Precalculate [omega, omega^2, omega^4, omega^8, ..., omega^(2^31)]
-        let mut tom = vec![structs::PrimeFieldStruct::<F>::default(); 32];
-        let om = unsafe { std::mem::transmute::<&mut [structs::PrimeFieldStruct::<F>], &mut [F]>(&mut tom) };
+        let mut tom = vec![structs::PrimeFieldStruct::<E::Fr>::default(); 32];
+        let om = unsafe { std::mem::transmute::<&mut [structs::PrimeFieldStruct::<E::Fr>], &mut [E::Fr]>(&mut tom) };
         om[0] = *omega;
         for i in 1..LOG2_MAX_ELEMENTS { om[i] = om[i-1].pow([2u64]); }
         self.fft_omg_buffer.write(&tom).enq()?;
@@ -104,10 +110,10 @@ impl<F> FFTKernel<F> where F: PrimeField {
     /// Performs FFT on `a`
     /// * `omega` - Special value `omega` is used for FFT over finite-fields
     /// * `lgn` - Specifies log2 of number of elements
-    pub fn radix_fft(&mut self, a: &mut [F], omega: &F, lgn: u32) -> GPUResult<()> {
+    pub fn radix_fft(&mut self, a: &mut [E::Fr], omega: &E::Fr, lgn: u32) -> GPUResult<()> {
         let n = 1 << lgn;
 
-        let ta = unsafe { std::mem::transmute::<&mut [F], &mut [structs::PrimeFieldStruct::<F>]>(a) };
+        let ta = unsafe { std::mem::transmute::<&mut [E::Fr], &mut [structs::PrimeFieldStruct::<E::Fr>]>(a) };
 
         let max_deg = cmp::min(MAX_RADIX_DEGREE, lgn);
         self.setup_pq(omega, n, max_deg)?;
@@ -130,10 +136,10 @@ impl<F> FFTKernel<F> where F: PrimeField {
 
     /// Multiplies all of the elements in `a` by `field`
     /// * `lgn` - Specifies log2 of number of elements
-    pub fn mul_by_field(&mut self, a: &mut [F], field: &F, lgn: u32) -> GPUResult<()> {
+    pub fn mul_by_field(&mut self, a: &mut [E::Fr], field: &E::Fr, lgn: u32) -> GPUResult<()> {
         let n = 1u32 << lgn;
-        let ta = unsafe { std::mem::transmute::<&mut [F], &mut [structs::PrimeFieldStruct::<F>]>(a) };
-        let field = structs::PrimeFieldStruct::<F>(*field);
+        let ta = unsafe { std::mem::transmute::<&mut [E::Fr], &mut [structs::PrimeFieldStruct::<E::Fr>]>(a) };
+        let field = structs::PrimeFieldStruct::<E::Fr>(*field);
         self.fft_src_buffer.write(&*ta).enq()?;
         let kernel = self.proque.kernel_builder("mul_by_field")
             .global_work_size([n])

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -23,7 +23,7 @@ pub struct FFTKernel<F> where F: PrimeField {
 impl<F> FFTKernel<F> where F: PrimeField {
 
     pub fn create(n: u32) -> GPUResult<FFTKernel::<F>> {
-        if BLS12_KERNELS.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
+        if BLS12_KERNELS.is_empty() { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
         let pq = BLS12_KERNELS[0].clone();
         let srcbuff = Buffer::builder().queue(pq.queue().clone())
             .flags(MemFlags::new().read_write()).len(n)

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -3,7 +3,6 @@ use ocl::{ProQue, Buffer, MemFlags};
 use std::cmp;
 use ff::PrimeField;
 use super::error::{GPUResult, GPUError};
-use super::sources;
 use super::structs;
 use super::utils;
 

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -24,11 +24,8 @@ pub struct FFTKernel<F> where F: PrimeField {
 impl<F> FFTKernel<F> where F: PrimeField {
 
     pub fn create(n: u32) -> GPUResult<FFTKernel::<F>> {
-        let src = sources::fft_kernel::<F>();
-        let devices = &utils::GPU_NVIDIA_DEVICES;
-        if devices.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
-        let device = devices[0]; // Select the first device for FFT
-        let pq = ProQue::builder().device(device).src(src).dims(n).build()?;
+        if utils::BLS12_KERNELS.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
+        let pq = utils::BLS12_KERNELS[0].clone();
         let srcbuff = Buffer::builder().queue(pq.queue().clone())
             .flags(MemFlags::new().read_write()).len(n)
             .build()?;

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -41,22 +41,20 @@ use log::info;
 lazy_static! {
     pub static ref BLS12_KERNELS: Vec<ProQue> = {
         get_devices(GPU_NVIDIA_PLATFORM_NAME)
-            .unwrap_or(Vec::new())
+            .unwrap_or_default()
             .iter()
             .map(|d| {
                 let src = sources::kernel::<Bls12>();
                 (d, ProQue::builder().device(d).src(src).build())
             })
-            .filter(|(d, res)| {
+            .filter_map(|(d, res)| {
                 if res.is_err() {
                     info!("Cannot compile kernel for device: {}", d.name().unwrap_or("Unknown".to_string()));
+                    return None;
                 }
-                res.is_ok()
-            })
-            .map(|(d, res)| {
                 let pq = res.unwrap();
                 info!("Kernel compiled for device: {}", d.name().unwrap_or("Unknown".to_string()));
-                pq
+                Some(pq)
             })
             .collect()
     };

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -45,12 +45,17 @@ lazy_static! {
             .iter()
             .map(|d| {
                 let src = sources::kernel::<Bls12>();
-                ProQue::builder().device(d).src(src).build()
+                (d, ProQue::builder().device(d).src(src).build())
             })
-            .filter(|res| res.is_ok())
-            .map(|res| {
+            .filter(|(d, res)| {
+                if res.is_err() {
+                    info!("Cannot compile kernel for device: {}", d.name().unwrap_or("Unknown".to_string()));
+                }
+                res.is_ok()
+            })
+            .map(|(d, res)| {
                 let pq = res.unwrap();
-                info!("Kernel initialized for device: {}", pq.device().name().unwrap_or("Unknown".to_string()));
+                info!("Kernel compiled for device: {}", d.name().unwrap_or("Unknown".to_string()));
                 pq
             })
             .collect()

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -40,7 +40,7 @@ use log::info;
 #[cfg(feature = "gpu")]
 lazy_static! {
     pub static ref BLS12_KERNELS: Vec<ProQue> = {
-        get_devices(CPU_INTEL_PLATFORM_NAME)
+        get_devices(GPU_NVIDIA_PLATFORM_NAME)
             .unwrap_or(Vec::new())
             .iter()
             .map(|d| {

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -32,14 +32,12 @@ mod nogpu;
 pub use self::nogpu::*;
 
 #[cfg(feature = "gpu")]
-use paired::bls12_381::Bls12;
-#[cfg(feature = "gpu")]
 use ocl::ProQue;
-#[cfg(feature = "gpu")]
-use log::info;
 #[cfg(feature = "gpu")]
 lazy_static! {
     pub static ref BLS12_KERNELS: Vec<ProQue> = {
+        use paired::bls12_381::Bls12;
+        use log::info;
         get_devices(GPU_NVIDIA_PLATFORM_NAME)
             .unwrap_or_default()
             .iter()

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -32,28 +32,10 @@ mod nogpu;
 pub use self::nogpu::*;
 
 #[cfg(feature = "gpu")]
-use ocl::ProQue;
+use ocl::Device;
 #[cfg(feature = "gpu")]
 lazy_static! {
-    pub static ref BLS12_KERNELS: Vec<ProQue> = {
-        use paired::bls12_381::Bls12;
-        use log::info;
-        get_devices(GPU_NVIDIA_PLATFORM_NAME)
-            .unwrap_or_default()
-            .iter()
-            .map(|d| {
-                let src = sources::kernel::<Bls12>();
-                (d, ProQue::builder().device(d).src(src).build())
-            })
-            .filter_map(|(d, res)| {
-                if res.is_err() {
-                    info!("Cannot compile kernel for device: {}", d.name().unwrap_or("Unknown".to_string()));
-                    return None;
-                }
-                let pq = res.unwrap();
-                info!("Kernel compiled for device: {}", d.name().unwrap_or("Unknown".to_string()));
-                Some(pq)
-            })
-            .collect()
+    pub static ref GPU_NVIDIA_DEVICES: Vec<Device> = {
+        get_devices(GPU_NVIDIA_PLATFORM_NAME).unwrap_or(Vec::new())
     };
 }

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -31,9 +31,13 @@ mod nogpu;
 #[cfg(not (feature = "gpu"))]
 pub use self::nogpu::*;
 
+#[cfg(feature = "gpu")]
 use paired::bls12_381::Bls12;
+#[cfg(feature = "gpu")]
 use ocl::ProQue;
+#[cfg(feature = "gpu")]
 use log::info;
+#[cfg(feature = "gpu")]
 lazy_static! {
     pub static ref BLS12_KERNELS: Vec<ProQue> = {
         get_devices(CPU_INTEL_PLATFORM_NAME)

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -140,10 +140,10 @@ pub struct MultiexpKernel<E>(Vec<SingleMultiexpKernel<E>>) where E: Engine;
 impl<E> MultiexpKernel<E> where E: Engine {
 
     pub fn create() -> GPUResult<MultiexpKernel<E>> {
-        let devices = utils::get_devices(utils::GPU_NVIDIA_PLATFORM_NAME)?;
+        let devices = &utils::GPU_NVIDIA_DEVICES;
         if devices.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
         let mut kernels = Vec::new();
-        for dev in devices.into_iter().map(|device| { SingleMultiexpKernel::<E>::create(device, CHUNK_SIZE as u32) }) {
+        for dev in devices.iter().map(|device| { SingleMultiexpKernel::<E>::create(*device, CHUNK_SIZE as u32) }) {
             kernels.push(dev?);
         }
         info!("Multiexp: {} working device(s) selected.", kernels.len());

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -1,11 +1,10 @@
 use log::info;
-use ocl::{ProQue, Buffer, MemFlags, Device};
+use ocl::{ProQue, Buffer, MemFlags};
 use paired::Engine;
 use std::sync::Arc;
 use ff::{PrimeField, ScalarEngine};
 use paired::{CurveAffine, CurveProjective};
 use super::error::{GPUResult, GPUError};
-use super::sources;
 use super::structs;
 use super::utils;
 use crossbeam::thread;

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -142,11 +142,10 @@ pub struct MultiexpKernel<E> where E: Engine {
 impl<E> MultiexpKernel<E> where E: Engine {
 
     pub fn create(chunk_size: usize) -> GPUResult<MultiexpKernel<E>> {
-        let devices = &GPU_NVIDIA_DEVICES;
-        if devices.is_empty() { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
-        let kernels : Vec<_> = devices.iter().map(|d| {
+        let kernels : Vec<_> = GPU_NVIDIA_DEVICES.iter().map(|d| {
             SingleMultiexpKernel::<E>::create(*d, chunk_size as u32)
         }).filter(|res| res.is_ok()).map(|res| res.unwrap()).collect();
+        if kernels.is_empty() { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
         info!("Multiexp: {} working device(s) selected.", kernels.len());
         for (i, k) in kernels.iter().enumerate() {
             info!("Multiexp: Device {}: {}", i, k.proque.device().name()?);

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -176,7 +176,7 @@ impl<E> MultiexpKernel<E> where E: Engine {
                 threads.push(s.spawn(move |_| -> Result<<G as CurveAffine>::Projective, GPUError> {
                     let mut acc = <G as CurveAffine>::Projective::zero();
                     for (bases, exps) in bases.chunks(device_chunk_size).zip(exps.chunks(device_chunk_size)) {
-                        let result = kern.multiexp(bases, exps, bases.len()).unwrap();
+                        let result = kern.multiexp(bases, exps, bases.len())?;
                         acc.add_assign(&result);
                     }
                     Ok(acc)

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -138,7 +138,7 @@ pub struct MultiexpKernel<E> where E: Engine {
 impl<E> MultiexpKernel<E> where E: Engine {
 
     pub fn create(chunk_size: usize) -> GPUResult<MultiexpKernel<E>> {
-        if BLS12_KERNELS.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
+        if BLS12_KERNELS.is_empty() { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
         let kernels : Vec<_> = BLS12_KERNELS.iter().map(|pq| {
             SingleMultiexpKernel::<E>::create(pq.clone(), chunk_size as u32)
         }).filter(|res| res.is_ok()).map(|res| res.unwrap()).collect();

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -6,7 +6,7 @@ use ff::{PrimeField, ScalarEngine};
 use paired::{CurveAffine, CurveProjective};
 use super::error::{GPUResult, GPUError};
 use super::structs;
-use super::utils;
+use super::BLS12_KERNELS;
 use crossbeam::thread;
 
 // NOTE: Please read `structs.rs` for an explanation for unsafe transmutes of this code!
@@ -138,8 +138,8 @@ pub struct MultiexpKernel<E> where E: Engine {
 impl<E> MultiexpKernel<E> where E: Engine {
 
     pub fn create(chunk_size: usize) -> GPUResult<MultiexpKernel<E>> {
-        if utils::BLS12_KERNELS.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
-        let kernels : Vec<_> = utils::BLS12_KERNELS.iter().map(|pq| {
+        if BLS12_KERNELS.len() == 0 { return Err(GPUError {msg: "No working GPUs found!".to_string()} ); }
+        let kernels : Vec<_> = BLS12_KERNELS.iter().map(|pq| {
             SingleMultiexpKernel::<E>::create(pq.clone(), chunk_size as u32)
         }).filter(|res| res.is_ok()).map(|res| res.unwrap()).collect();
         info!("Multiexp: {} working device(s) selected.", kernels.len());

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -6,19 +6,19 @@ use super::error::{GPUResult, GPUError};
 
 // This module is compiled instead of `fft.rs` and `multiexp.rs` if `gpu` feature is disabled.
 
-pub struct FFTKernel<F>(PhantomData::<F>) where F: PrimeField;
+pub struct FFTKernel<E>(PhantomData::<E>) where E: Engine;
 
-impl<F> FFTKernel<F> where F: PrimeField {
+impl<E> FFTKernel<E> where E: Engine {
 
-    pub fn create(_: u32) -> GPUResult<FFTKernel::<F>> {
+    pub fn create(_: u32) -> GPUResult<FFTKernel::<E>> {
         return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
     }
 
-    pub fn radix_fft(&mut self, _: &mut [F], _: &F, _: u32) -> GPUResult<()> {
+    pub fn radix_fft(&mut self, _: &mut [E::Fr], _: &E::Fr, _: u32) -> GPUResult<()> {
         return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
     }
 
-    pub fn mul_by_field(&mut self, _: &mut [F], _: &F, _: u32) -> GPUResult<()> {
+    pub fn mul_by_field(&mut self, _: &mut [E::Fr], _: &E::Fr, _: u32) -> GPUResult<()> {
         return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
     }
 }

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -27,7 +27,7 @@ pub struct MultiexpKernel<E>(PhantomData::<E>) where E: Engine;
 
 impl<E> MultiexpKernel<E> where E: Engine {
 
-    pub fn create() -> GPUResult<MultiexpKernel<E>> {
+    pub fn create(_: u32) -> GPUResult<MultiexpKernel<E>> {
         return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
     }
 

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -27,7 +27,7 @@ pub struct MultiexpKernel<E>(PhantomData::<E>) where E: Engine;
 
 impl<E> MultiexpKernel<E> where E: Engine {
 
-    pub fn create(_: u32) -> GPUResult<MultiexpKernel<E>> {
+    pub fn create(_: usize) -> GPUResult<MultiexpKernel<E>> {
         return Err(GPUError {msg: "GPU accelerator is not enabled!".to_string()});
     }
 

--- a/src/gpu/sources.rs
+++ b/src/gpu/sources.rs
@@ -81,21 +81,7 @@ fn multiexp(point: &str, exp: &str) -> String {
         .replace("EXPONENT", exp);;
 }
 
-pub fn fft_kernel<F>() -> String where F: PrimeField {
-    return String::from(format!("{}\n{}\n{}",
-        DEFS_SRC,
-        field::<F>("Fr"), fft("Fr")));
-}
-
 // WARNING: This function works only with Short Weierstrass Jacobian curves with Fq2 extension field.
-pub fn multiexp_kernel<E>() -> String where E: Engine {
-    return String::from(format!("{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
-        DEFS_SRC,
-        exponent::<E::Fr>("Exp"),
-        field::<E::Fq>("Fq"), ec("Fq", "G1"), multiexp("G1", "Exp"),
-        field2("Fq2", "Fq"), ec("Fq2", "G2"), multiexp("G2", "Exp")));
-}
-
 pub fn kernel<E>() -> String where E: Engine {
     return String::from(format!("{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
         DEFS_SRC,

--- a/src/gpu/sources.rs
+++ b/src/gpu/sources.rs
@@ -95,3 +95,12 @@ pub fn multiexp_kernel<E>() -> String where E: Engine {
         field::<E::Fq>("Fq"), ec("Fq", "G1"), multiexp("G1", "Exp"),
         field2("Fq2", "Fq"), ec("Fq2", "G2"), multiexp("G2", "Exp")));
 }
+
+pub fn kernel<E>() -> String where E: Engine {
+    return String::from(format!("{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        DEFS_SRC,
+        field::<E::Fr>("Fr"), fft("Fr"),
+        exponent::<E::Fr>("Exp"),
+        field::<E::Fq>("Fq"), ec("Fq", "G1"), multiexp("G1", "Exp"),
+        field2("Fq2", "Fq"), ec("Fq2", "G2"), multiexp("G2", "Exp")));
+}

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -18,3 +18,9 @@ pub fn get_devices(platform_name: &str) -> GPUResult<Vec<Device>> {
         Err(_) => Err(GPUError {msg: "GPU platform not found!".to_string()})
     }
 }
+
+lazy_static! {
+    pub static ref GPU_NVIDIA_DEVICES: Vec<Device> = {
+        get_devices(GPU_NVIDIA_PLATFORM_NAME).unwrap_or(Vec::new())
+    };
+}

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -1,7 +1,6 @@
-use ocl::{Device, Platform, ProQue};
+use ocl::{Device, Platform};
 use std::panic;
 use super::error::{GPUResult, GPUError};
-use super::sources;
 
 pub const GPU_NVIDIA_PLATFORM_NAME : &str = "NVIDIA CUDA";
 pub const CPU_INTEL_PLATFORM_NAME : &str = "Intel(R) CPU Runtime for OpenCL(TM) Applications";

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -22,7 +22,7 @@ pub fn get_devices(platform_name: &str) -> GPUResult<Vec<Device>> {
 
 lazy_static! {
     pub static ref DEVICES: Vec<Device> = {
-        get_devices(CPU_INTEL_PLATFORM_NAME).unwrap_or(Vec::new())
+        get_devices(GPU_NVIDIA_PLATFORM_NAME).unwrap_or(Vec::new())
     };
 }
 

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -1,3 +1,4 @@
+use log::info;
 use ocl::{Device, Platform, ProQue};
 use std::panic;
 use super::error::{GPUResult, GPUError};
@@ -30,7 +31,12 @@ lazy_static! {
                 let src = sources::kernel::<Bls12>();
                 ProQue::builder().device(d).src(src).build()
             })
-            .filter(|res| res.is_ok()).map(|res| res.unwrap())
+            .filter(|res| res.is_ok())
+            .map(|res| {
+                let pq = res.unwrap();
+                info!("Kernel initialized for device: {}", pq.device().name().unwrap_or("Unknown".to_string()));
+                pq
+            })
             .collect()
     };
 }

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -1,4 +1,3 @@
-use log::info;
 use ocl::{Device, Platform, ProQue};
 use std::panic;
 use super::error::{GPUResult, GPUError};
@@ -19,24 +18,4 @@ pub fn get_devices(platform_name: &str) -> GPUResult<Vec<Device>> {
         Ok(devs) => Ok(devs),
         Err(_) => Err(GPUError {msg: "GPU platform not found!".to_string()})
     }
-}
-
-use paired::bls12_381::Bls12;
-lazy_static! {
-    pub static ref BLS12_KERNELS: Vec<ProQue> = {
-        get_devices(GPU_NVIDIA_PLATFORM_NAME)
-            .unwrap_or(Vec::new())
-            .iter()
-            .map(|d| {
-                let src = sources::kernel::<Bls12>();
-                ProQue::builder().device(d).src(src).build()
-            })
-            .filter(|res| res.is_ok())
-            .map(|res| {
-                let pq = res.unwrap();
-                info!("Kernel initialized for device: {}", pq.device().name().unwrap_or("Unknown".to_string()));
-                pq
-            })
-            .collect()
-    };
 }

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -20,16 +20,11 @@ pub fn get_devices(platform_name: &str) -> GPUResult<Vec<Device>> {
     }
 }
 
-lazy_static! {
-    pub static ref DEVICES: Vec<Device> = {
-        get_devices(GPU_NVIDIA_PLATFORM_NAME).unwrap_or(Vec::new())
-    };
-}
-
 use paired::bls12_381::Bls12;
 lazy_static! {
     pub static ref BLS12_KERNELS: Vec<ProQue> = {
-        DEVICES
+        get_devices(GPU_NVIDIA_PLATFORM_NAME)
+            .unwrap_or(Vec::new())
             .iter()
             .map(|d| {
                 let src = sources::kernel::<Bls12>();

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -241,7 +241,7 @@ where
         Arc::new(a.into_iter().map(|s| s.0.into_repr()).collect::<Vec<_>>())
     };
 
-    let mut multiexp_kern = gpu_multiexp_supported::<E>(log_d).ok();
+    let mut multiexp_kern = gpu_multiexp_supported::<E>().ok();
     if multiexp_kern.is_some() { info!("GPU Multiexp is supported!"); }
     else { info!("GPU Multiexp is NOT supported!"); }
 

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -374,7 +374,7 @@ pub fn gpu_multiexp_consistency() {
     const CHUNK_SIZE: usize = 1048576;
     const MAX_LOG_D: usize = 20;
     const START_LOG_D: usize = 10;
-    let mut kern = gpu::MultiexpKernel::<Bls12>::create(CHUNK_SIZE).ok();
+    let mut kern = gpu::MultiexpKernel::<Bls12>::create(CHUNK_SIZE as u32).ok();
     if kern.is_none() { panic!("Cannot initialize kernel!"); }
     let pool = Worker::new();
 

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -346,7 +346,7 @@ fn test_with_bls12() {
     assert_eq!(naive, fast);
 }
 
-pub fn gpu_multiexp_supported<E>(log_d: u32) -> gpu::GPUResult<gpu::MultiexpKernel<E>> where E: Engine {
+pub fn gpu_multiexp_supported<E>() -> gpu::GPUResult<gpu::MultiexpKernel<E>> where E: Engine {
     const TEST_SIZE : u32 = 1024;
     use rand::Rand;
     let pool = Worker::new();

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -348,7 +348,7 @@ fn test_with_bls12() {
 
 pub fn gpu_multiexp_supported<E>() -> gpu::GPUResult<gpu::MultiexpKernel<E>> where E: Engine {
     const TEST_SIZE : u32 = 1024;
-    const CHUNK_SIZE: u32 = 8388608;
+    const CHUNK_SIZE: usize = 8388608;
     use rand::Rand;
     let pool = Worker::new();
     let rng = &mut rand::thread_rng();
@@ -374,7 +374,7 @@ pub fn gpu_multiexp_consistency() {
     const CHUNK_SIZE: usize = 1048576;
     const MAX_LOG_D: usize = 20;
     const START_LOG_D: usize = 10;
-    let mut kern = gpu::MultiexpKernel::<Bls12>::create(CHUNK_SIZE as u32).ok();
+    let mut kern = gpu::MultiexpKernel::<Bls12>::create(CHUNK_SIZE).ok();
     if kern.is_none() { panic!("Cannot initialize kernel!"); }
     let pool = Worker::new();
 

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -348,10 +348,11 @@ fn test_with_bls12() {
 
 pub fn gpu_multiexp_supported<E>() -> gpu::GPUResult<gpu::MultiexpKernel<E>> where E: Engine {
     const TEST_SIZE : u32 = 1024;
+    const CHUNK_SIZE: u32 = 8388608;
     use rand::Rand;
     let pool = Worker::new();
     let rng = &mut rand::thread_rng();
-    let mut kern = Some(gpu::MultiexpKernel::<E>::create()?);
+    let mut kern = Some(gpu::MultiexpKernel::<E>::create(CHUNK_SIZE)?);
     let bases_g1 = Arc::new((0..TEST_SIZE).map(|_| E::G1::rand(rng).into_affine()).collect::<Vec<_>>());
     let bases_g2 = Arc::new((0..TEST_SIZE).map(|_| E::G2::rand(rng).into_affine()).collect::<Vec<_>>());
     let exps = Arc::new((0..TEST_SIZE).map(|_| E::Fr::rand(rng).into_repr()).collect::<Vec<_>>());
@@ -370,9 +371,10 @@ pub fn gpu_multiexp_consistency() {
     use paired::bls12_381::Bls12;
     use rand::{self, Rand};
 
+    const CHUNK_SIZE: usize = 1048576;
     const MAX_LOG_D: usize = 20;
     const START_LOG_D: usize = 10;
-    let mut kern = gpu::MultiexpKernel::<Bls12>::create().ok();
+    let mut kern = gpu::MultiexpKernel::<Bls12>::create(CHUNK_SIZE).ok();
     if kern.is_none() { panic!("Cannot initialize kernel!"); }
     let pool = Worker::new();
 


### PR DESCRIPTION
~~Now it lazily instantiates Bls12-381 kernels in a global static variable and uses them instead of compiling the kernels each time `create_proof` is called.~~
UPDATE: Now, instead of having global static ProQues, we have combined the source code of FFT and Multiexp kernels. This makes the Multiexp and FFT kernel objects use the same codes and thus it enables the Nvidia driver to cache the whole binary once, making compilation times near zero.
Other changes:
- CHUNK_SIZE is now 8,388,608 (Allowing wider variety of NVIDIA cards to run support this work)
- It doesn't print the panic logs anymore (Solving https://github.com/filecoin-project/rust-fil-proofs/issues/931)

**Issues:**
- ~~Curves other than Bls12-381 are going to conflict with the static global variable mentioned since it is only instantiated for Bls12-381. How can we create generic static variables?~~