### PR TITLE
fix: move bad multiexp from GPU to CPU

### DIFF
--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -298,7 +298,7 @@ where
         a_aux_source,
         Arc::new(prover.a_aux_density),
         aux_assignment.clone(),
-        &mut None,
+        &mut None, // GPU kernel option removed until https://github.com/finalitylabs/bellman/issues/1 is resolved
     );
 
     let b_input_density = Arc::new(prover.b_input_density);

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -298,7 +298,7 @@ where
         a_aux_source,
         Arc::new(prover.a_aux_density),
         aux_assignment.clone(),
-        &mut multiexp_kern,
+        &mut None,
     );
 
     let b_input_density = Arc::new(prover.b_input_density);


### PR DESCRIPTION
This simply removes the GPU computation of the a_aux multiexp that is broken so that the rest of the prover can continue in the mean time. 