### PR TITLE
feat(gpu): enable custom gpus

### DIFF
--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -27,16 +27,29 @@ pub fn get_devices(platform_name: &str) -> GPUResult<Vec<Device>> {
 }
 
 lazy_static::lazy_static! {
-    static ref CORE_COUNTS: HashMap<&'static str, usize> = vec![
-        ("GeForce RTX 2080 Ti", 4352),
-        ("GeForce RTX 2080 SUPER", 3072),
-        ("GeForce RTX 2080", 2944),
-        ("GeForce GTX 1080 Ti", 3584),
-        ("GeForce GTX 1080", 2560),
-        ("GeForce GTX 1060", 1280),
-    ]
-    .into_iter()
-    .collect();
+    static ref CORE_COUNTS: HashMap<String, usize> = {
+        let mut core_counts : HashMap<String, usize> = vec![
+            ("GeForce RTX 2080 Ti".to_string(), 4352),
+            ("GeForce RTX 2080 SUPER".to_string(), 3072),
+            ("GeForce RTX 2080".to_string(), 2944),
+            ("GeForce GTX 1080 Ti".to_string(), 3584),
+            ("GeForce GTX 1080".to_string(), 2560),
+            ("GeForce GTX 1060".to_string(), 1280),
+        ].into_iter().collect();
+
+        env::var("BELLMAN_CUSTOM_GPU").and_then(|var| {
+            for card in var.split(",") {
+                let splitted = card.split(":").collect::<Vec<_>>();
+                if splitted.len() != 2 { panic!("Invalid BELLMAN_CUSTOM_GPU!"); }
+                let name = splitted[0].trim().to_string();
+                let cores : usize = splitted[1].trim().parse().expect("Invalid BELLMAN_CUSTOM_GPU!");
+                core_counts.insert(name, cores);
+            }
+            Ok(())
+        }).unwrap();
+
+        core_counts
+    };
 }
 
 pub fn get_core_count(d: Device) -> GPUResult<usize> {


### PR DESCRIPTION
The `BELLMAN_CUSTOM_GPU` environment variable allows you to run bellman prover on GPUs that are not explicitly supported in the current version of bellman library.
Usage:
```> BELLMAN_CUSTOM_GPU="<card name>:<cuda cores>,<card name>:<cuda cores>,..."```
`<card name>` can be found through running `clinfo` command, shown after `Device Name`.
`<cuda cores>` is also available in official specifications of that card.

E.g.
You can add Nvidia GeForce GTX 1050Ti like this:
```> BELLMAN_CUSTOM_GPU="GeForce GTX 1050 Ti:768"```

References:
https://github.com/filecoin-project/bellman/issues/24