### PR TITLE
feat(gpu): global lock on create_proof / interprocess termination of kernels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4.8"
 lazy_static = "1.4.0"
 ocl = { version = "0.19.4", package = "fil-ocl", optional = true }
 itertools = { version = "0.8.0", optional = true }
-nix = { version = "0.16.0", optional = true }
+fs2 = { version = "0.4.3", optional = true }
 rand = "0.7"
 
 [dev-dependencies]
@@ -36,7 +36,7 @@ sha2 = "0.8"
 
 [features]
 default = ["groth16", "multicore"]
-gpu = ["ocl", "itertools", "nix"]
+gpu = ["ocl", "itertools", "fs2"]
 gpu-test = ["gpu"]
 groth16 = ["paired"]
 multicore = ["futures-cpupool", "crossbeam", "num_cpus"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4.8"
 lazy_static = "1.4.0"
 ocl = { version = "0.19.4", package = "fil-ocl", optional = true }
 itertools = { version = "0.8.0", optional = true }
+nix = { version = "0.16.0", optional = true }
 rand = "0.7"
 
 [dev-dependencies]
@@ -35,7 +36,7 @@ sha2 = "0.8"
 
 [features]
 default = ["groth16", "multicore"]
-gpu = ["ocl", "itertools"]
+gpu = ["ocl", "itertools", "nix"]
 gpu-test = ["gpu"]
 groth16 = ["paired"]
 multicore = ["futures-cpupool", "crossbeam", "num_cpus"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.7"
 hex-literal = "0.2"
 rand_xorshift = "0.2"
 sha2 = "0.8"
+env_logger = "0.7.1"
 
 [features]
 default = ["groth16", "multicore"]

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -1,6 +1,6 @@
 use crate::gpu::{
     error::{GPUError, GPUResult},
-    sources, structs, GPU_NVIDIA_DEVICES,
+    sources, structs, utils, GPU_NVIDIA_DEVICES,
 };
 use ff::Field;
 use log::info;
@@ -85,7 +85,13 @@ where
         deg: u32,
         max_deg: u32,
         in_src: bool,
-    ) -> ocl::Result<()> {
+    ) -> GPUResult<()> {
+        if !utils::gpu_is_available() {
+            return Err(GPUError {
+                msg: "GPU is forcefully taken by another process!".to_string(),
+            });
+        }
+
         let n = 1u32 << lgn;
         let lwsd = cmp::min(deg - 1, MAX_LOCAL_WORK_SIZE_DEGREE);
         let kernel = self

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -37,3 +37,23 @@ use ocl::Device;
 lazy_static::lazy_static! {
     pub static ref GPU_NVIDIA_DEVICES: Vec<Device> = get_devices(GPU_NVIDIA_PLATFORM_NAME).unwrap_or_default();
 }
+
+use std::fs::File;
+pub const LOCK_NAME: &str = "/tmp/bellman.lock";
+pub fn lock() -> File {
+    let file = File::create(LOCK_NAME).unwrap();
+
+    #[cfg(feature = "gpu")]
+    {
+        use std::os::unix::io::AsRawFd;
+        use nix::fcntl::{flock, FlockArg};
+        let fd = file.as_raw_fd();
+        flock(fd, FlockArg::LockExclusive).unwrap();
+    }
+
+    file
+}
+
+pub fn unlock(lock: File) {
+    drop(lock);
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -45,8 +45,8 @@ pub fn lock() -> File {
 
     #[cfg(feature = "gpu")]
     {
-        use std::os::unix::io::AsRawFd;
         use nix::fcntl::{flock, FlockArg};
+        use std::os::unix::io::AsRawFd;
         let fd = file.as_raw_fd();
         flock(fd, FlockArg::LockExclusive).unwrap();
     }

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -141,6 +141,12 @@ where
     where
         G: CurveAffine,
     {
+        if !utils::gpu_is_available() {
+            return Err(GPUError {
+                msg: "GPU is forcefully taken by another process!".to_string(),
+            });
+        }
+
         let exp_bits = std::mem::size_of::<E::Fr>() * 8;
         let num_windows = ((exp_bits as f64) / (self.window_size as f64)).ceil() as usize;
 

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -62,3 +62,16 @@ pub fn get_core_count(d: Device) -> GPUResult<usize> {
         }),
     }
 }
+
+use std::fs::{remove_file, File};
+use std::path::Path;
+pub const FILE_NAME: &str = "/tmp/bellman_gpu.lock";
+pub fn gpu_acquire() {
+    File::create(FILE_NAME).unwrap();
+}
+pub fn gpu_release() {
+    remove_file(FILE_NAME).unwrap();
+}
+pub fn gpu_is_available() -> bool {
+    !Path::new(FILE_NAME).exists()
+}

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -182,7 +182,7 @@ where
     E: Engine,
     C: Circuit<E>,
 {
-    let lck = gpu::lock();
+    let lck = gpu::lock().expect("Cannot obtain prover lock!");
 
     let mut prover = ProvingAssignment {
         a_aux_density: DensityTracker::new(),

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -10,10 +10,10 @@ use paired::Engine;
 
 use super::{ParameterSource, Proof};
 use crate::domain::{gpu_fft_supported, EvaluationDomain, Scalar};
+use crate::gpu;
 use crate::multicore::Worker;
 use crate::multiexp::{gpu_multiexp_supported, multiexp, DensityTracker, FullDensity};
 use crate::{Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
-use crate::gpu;
 
 fn eval<E: Engine>(
     lc: &LinearCombination<E>,

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -13,6 +13,7 @@ use crate::domain::{gpu_fft_supported, EvaluationDomain, Scalar};
 use crate::multicore::Worker;
 use crate::multiexp::{gpu_multiexp_supported, multiexp, DensityTracker, FullDensity};
 use crate::{Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+use crate::gpu;
 
 fn eval<E: Engine>(
     lc: &LinearCombination<E>,
@@ -181,6 +182,8 @@ where
     E: Engine,
     C: Circuit<E>,
 {
+    let lck = gpu::lock();
+
     let mut prover = ProvingAssignment {
         a_aux_density: DensityTracker::new(),
         b_input_density: DensityTracker::new(),
@@ -377,6 +380,8 @@ where
     g_c.add_assign(&b1_answer);
     g_c.add_assign(&h.wait()?);
     g_c.add_assign(&l.wait()?);
+
+    gpu::unlock(lck);
 
     Ok(Proof {
         a: g_a.into_affine(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,19 @@ use std::io;
 use std::marker::PhantomData;
 use std::ops::{Add, Sub};
 
+#[cfg(feature = "gpu")]
+pub fn gpu_acquire() {
+    gpu::gpu_acquire();
+}
+#[cfg(feature = "gpu")]
+pub fn gpu_release() {
+    gpu::gpu_release();
+}
+#[cfg(feature = "gpu")]
+pub fn gpu_is_available() -> bool {
+    gpu::gpu_is_available()
+}
+
 /// Computations are expressed in terms of arithmetic circuits, in particular
 /// rank-1 quadratic constraint systems. The `Circuit` trait represents a
 /// circuit that can be synthesized. The `synthesize` method is called during

--- a/tests/gpu_provers.rs
+++ b/tests/gpu_provers.rs
@@ -1,0 +1,164 @@
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+extern crate bellperson;
+extern crate paired;
+extern crate rand;
+extern crate ff;
+extern crate log;
+use bellperson::{Circuit, ConstraintSystem, SynthesisError};
+use bellperson::groth16::{Parameters};
+use paired::{Engine};
+use ff::{Field, PrimeField};
+
+use std::fs::File;
+use std::io::prelude::*;
+
+use std::time::{Duration, Instant};
+use std::thread;
+
+// For randomness (during paramgen and proof generation)
+use self::rand::{thread_rng, Rng};
+
+// Bring in some tools for using pairing-friendly curves
+// use self::paired::{
+//     Engine
+// };
+
+//use self::ff::{Field,PrimeField};
+
+// We're going to use the BLS12-381 pairing-friendly elliptic curve.
+use self::paired::bls12_381::{
+    Bls12,
+    Fr
+};
+
+// We'll use these interfaces to construct our circuit.
+// use self::bellperson::{
+//     Circuit,
+//     ConstraintSystem,
+//     SynthesisError
+// };
+
+// We're going to use the Groth16 proving system.
+use self::bellperson::groth16::{
+    Proof,
+    generate_random_parameters,
+    prepare_verifying_key,
+    create_random_proof,
+    verify_proof,
+};
+
+#[derive(Clone)]
+pub struct DummyDemo<E: Engine> {
+    pub xx: Option<E::Fr>,
+}
+
+impl <E: Engine> Circuit<E> for DummyDemo<E> {
+    fn synthesize<CS: ConstraintSystem<E>>(
+        self,
+        cs: &mut CS
+    ) -> Result<(), SynthesisError>
+    {
+
+        let mut x_val = E::Fr::from_str("2");
+        let mut x = cs.alloc(|| "", || {
+            x_val.ok_or(SynthesisError::AssignmentMissing)
+        })?;
+
+        for k in 0..1_000 {
+            // Allocate: x * x = x2
+            let x2_val = x_val.map(|mut e| {
+                e.square();
+                e
+            });
+            let x2 = cs.alloc(|| "", || {
+                x2_val.ok_or(SynthesisError::AssignmentMissing)
+            })?;
+
+            // Enforce: x * x = x2
+            cs.enforce(
+                || "",
+                |lc| lc + x,
+                |lc| lc + x,
+                |lc| lc + x2
+            );
+
+            x = x2;
+            x_val = x2_val;
+        }
+
+        cs.enforce(
+            || "",
+            |lc| lc + (x_val.unwrap(), CS::one()),
+            |lc| lc + CS::one(),
+            |lc| lc + x
+        );
+
+        Ok(())
+    }
+}
+
+
+//mod dummy;
+
+#[cfg(feature = "gpu-test")]
+#[test]
+pub fn test_parallel_prover(){
+    env_logger::init();
+    use paired::bls12_381::{Bls12, Fr};
+    use rand::thread_rng;
+    use bellperson::groth16::{
+        create_proof, create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof, Proof,
+    };
+
+    println!("Initializing circuit...");
+
+    let rng = &mut thread_rng();
+
+    println!("Creating parameters...");
+
+    let c = DummyDemo::<Bls12> {
+        xx: None
+    };
+
+    let params = generate_random_parameters(c, rng).unwrap();
+
+    // Prepare the verification key (for proof verification)
+    let pvk = prepare_verifying_key(&params.vk);
+    let pvk2 = prepare_verifying_key(&params.vk);
+
+    //let now = Instant::now();
+
+    // Create an instance of circuit
+    let c = DummyDemo::<Bls12> {
+        xx: Fr::from_str("3")
+    };
+
+    // generate randomness
+    let r1 = Fr::random(rng);
+    let s1 = Fr::random(rng);
+    let r2 = Fr::random(rng);
+    let s2 = Fr::random(rng);
+    println!("Creating proof from LOWER priority process...");
+    // Create a groth16 proof with our parameters.
+    let proof_lower = create_proof(c.clone(), &params, r1, s1).unwrap();
+
+    thread::spawn(move || {
+        println!("Creating proof from HIGHER priority process...");
+        thread::sleep(Duration::from_millis(1));
+        let proof_higher = create_proof(c.clone(), &params, r2, s2).unwrap();
+        println!("{}", verify_proof(
+            &pvk2,
+            &proof_higher,
+            &[]
+        ).unwrap());
+    });
+
+    //println!("Total proof gen finished in {}s and {}ms", now.elapsed().as_secs(), now.elapsed().subsec_nanos()/1000000);
+
+    println!("{}", verify_proof(
+        &pvk,
+        &proof_lower,
+        &[]
+    ).unwrap());
+}


### PR DESCRIPTION
This PR solves the CL_MEM_ALLOCATION_ERRORs when proving multiple circuits at the same time by putting a global lock (Using file locks) all over the `create_proof` function.
Beside that, this PR also adds two new functions to the bellman api: `bellperson::gpu_acquire()` and `bellperson::gpu_release()` which are used to terminate other bellman instances when a request with more priority comes in.

Process A (With less priority):
```rust
// Blah blah
bellperson::groth16::create_proof(...); // This should fail sometime after the gpu_acquire function in Process B is called (Probably 200-300ms / JUST AN ESTIMATION!)
// Blah blah
```

Process B (With more priority):
```rust
// Blah blah
bellperson::gpu_acquire(); // Does NOT lock! It just causes all other `create_proofs` in other processes to fail.
bellperson::groth16::create_proof(...);
bellperson::gpu_release(); // Other processes can now run create_proof again.
// Blah blah
```

**IMPORTANT:** gpu_acquire/gpu_release do not behave like a regular mutex (A file-lock is NOT used behind the scenes), they are just being used for signaling other processes to forcefully finish their jobs. The actual file-lock is inside the create_proof function which then waits for other bellman processes to finish after receiving their termination signal.