### PR TITLE
feat(gpu): make GPU_NVIDIA_DEVICES public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,9 @@ pub mod groth16;
 pub mod multicore;
 pub mod multiexp;
 
+#[cfg(feature = "gpu")]
+pub use gpu::GPU_NVIDIA_DEVICES;
+
 use ff::{Field, ScalarEngine};
 
 use std::error::Error;


### PR DESCRIPTION
With exposing `gpu::GPU_NVIDIA_DEVICES` to the public API, you can get
a list of GPU devices that are supported on your machine.