### PR TITLE
feat(gpu): remove panics and propagate all gpu errors

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -84,12 +84,20 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
         })
     }
 
-    pub fn fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) -> gpu::GPUResult<()> {
+    pub fn fft(
+        &mut self,
+        worker: &Worker,
+        kern: &mut Option<gpu::FFTKernel<E>>,
+    ) -> gpu::GPUResult<()> {
         best_fft(kern, &mut self.coeffs, worker, &self.omega, self.exp)?;
         Ok(())
     }
 
-    pub fn ifft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) -> gpu::GPUResult<()> {
+    pub fn ifft(
+        &mut self,
+        worker: &Worker,
+        kern: &mut Option<gpu::FFTKernel<E>>,
+    ) -> gpu::GPUResult<()> {
         best_fft(kern, &mut self.coeffs, worker, &self.omegainv, self.exp)?;
 
         if let Some(ref mut k) = kern {
@@ -124,13 +132,21 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
         });
     }
 
-    pub fn coset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) -> gpu::GPUResult<()> {
+    pub fn coset_fft(
+        &mut self,
+        worker: &Worker,
+        kern: &mut Option<gpu::FFTKernel<E>>,
+    ) -> gpu::GPUResult<()> {
         self.distribute_powers(worker, E::Fr::multiplicative_generator());
         self.fft(worker, kern)?;
         Ok(())
     }
 
-    pub fn icoset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) -> gpu::GPUResult<()> {
+    pub fn icoset_fft(
+        &mut self,
+        worker: &Worker,
+        kern: &mut Option<gpu::FFTKernel<E>>,
+    ) -> gpu::GPUResult<()> {
         let geninv = self.geninv;
         self.ifft(worker, kern)?;
         self.distribute_powers(worker, geninv);
@@ -149,7 +165,11 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
     /// The target polynomial is the zero polynomial in our
     /// evaluation domain, so we must perform division over
     /// a coset.
-    pub fn divide_by_z_on_coset(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) -> gpu::GPUResult<()> {
+    pub fn divide_by_z_on_coset(
+        &mut self,
+        worker: &Worker,
+        kern: &mut Option<gpu::FFTKernel<E>>,
+    ) -> gpu::GPUResult<()> {
         let i = self
             .z(&E::Fr::multiplicative_generator())
             .inverse()

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -84,16 +84,16 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
         })
     }
 
-    pub fn fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) {
-        best_fft(kern, &mut self.coeffs, worker, &self.omega, self.exp);
+    pub fn fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) -> gpu::GPUResult<()> {
+        best_fft(kern, &mut self.coeffs, worker, &self.omega, self.exp)?;
+        Ok(())
     }
 
-    pub fn ifft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) {
-        best_fft(kern, &mut self.coeffs, worker, &self.omegainv, self.exp);
+    pub fn ifft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) -> gpu::GPUResult<()> {
+        best_fft(kern, &mut self.coeffs, worker, &self.omegainv, self.exp)?;
 
         if let Some(ref mut k) = kern {
-            gpu_mul_by_field(k, &mut self.coeffs, &self.minv, self.exp)
-                .expect("GPU Multiply By Field failed!");
+            gpu_mul_by_field(k, &mut self.coeffs, &self.minv, self.exp)?;
         } else {
             worker.scope(self.coeffs.len(), |scope, chunk| {
                 let minv = self.minv;
@@ -107,6 +107,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
                 }
             });
         }
+        Ok(())
     }
 
     pub fn distribute_powers(&mut self, worker: &Worker, g: E::Fr) {
@@ -123,16 +124,17 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
         });
     }
 
-    pub fn coset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) {
+    pub fn coset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) -> gpu::GPUResult<()> {
         self.distribute_powers(worker, E::Fr::multiplicative_generator());
-        self.fft(worker, kern);
+        self.fft(worker, kern)?;
+        Ok(())
     }
 
-    pub fn icoset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) {
+    pub fn icoset_fft(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) -> gpu::GPUResult<()> {
         let geninv = self.geninv;
-
-        self.ifft(worker, kern);
+        self.ifft(worker, kern)?;
         self.distribute_powers(worker, geninv);
+        Ok(())
     }
 
     /// This evaluates t(tau) for this domain, which is
@@ -147,15 +149,14 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
     /// The target polynomial is the zero polynomial in our
     /// evaluation domain, so we must perform division over
     /// a coset.
-    pub fn divide_by_z_on_coset(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) {
+    pub fn divide_by_z_on_coset(&mut self, worker: &Worker, kern: &mut Option<gpu::FFTKernel<E>>) -> gpu::GPUResult<()> {
         let i = self
             .z(&E::Fr::multiplicative_generator())
             .inverse()
             .unwrap();
 
         if let Some(ref mut k) = kern {
-            gpu_mul_by_field(k, &mut self.coeffs, &i, self.exp)
-                .expect("GPU Multiply By Field failed!");
+            gpu_mul_by_field(k, &mut self.coeffs, &i, self.exp)?;
         } else {
             worker.scope(self.coeffs.len(), |scope, chunk| {
                 for v in self.coeffs.chunks_mut(chunk) {
@@ -167,6 +168,8 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
                 }
             });
         }
+
+        Ok(())
     }
 
     /// Perform O(n) multiplication of two polynomials in the domain.
@@ -283,9 +286,9 @@ fn best_fft<E: Engine, T: Group<E>>(
     worker: &Worker,
     omega: &E::Fr,
     log_n: u32,
-) {
+) -> gpu::GPUResult<()> {
     if let Some(ref mut k) = kern {
-        gpu_fft(k, a, omega, log_n).expect("GPU FFT failed!");
+        gpu_fft(k, a, omega, log_n)?;
     } else {
         let log_cpus = worker.log_num_cpus();
         if log_n <= log_cpus {
@@ -294,6 +297,7 @@ fn best_fft<E: Engine, T: Group<E>>(
             parallel_fft(a, worker, omega, log_n, log_cpus);
         }
     }
+    Ok(())
 }
 
 pub fn gpu_fft<E: Engine, T: Group<E>>(

--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -270,7 +270,7 @@ where
     }
 
     // Use inverse FFT to convert powers of tau to Lagrange coefficients
-    powers_of_tau.ifft(&worker, &mut None);
+    powers_of_tau.ifft(&worker, &mut None)?;
     let powers_of_tau = powers_of_tau.into_coeffs();
 
     let mut a = vec![E::G1::zero(); assembly.num_inputs + assembly.num_aux];

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -227,19 +227,19 @@ where
         let mut b = EvaluationDomain::from_coeffs(prover.b)?;
         let mut c = EvaluationDomain::from_coeffs(prover.c)?;
 
-        a.ifft(&worker, &mut fft_kern);
-        a.coset_fft(&worker, &mut fft_kern);
-        b.ifft(&worker, &mut fft_kern);
-        b.coset_fft(&worker, &mut fft_kern);
-        c.ifft(&worker, &mut fft_kern);
-        c.coset_fft(&worker, &mut fft_kern);
+        a.ifft(&worker, &mut fft_kern)?;
+        a.coset_fft(&worker, &mut fft_kern)?;
+        b.ifft(&worker, &mut fft_kern)?;
+        b.coset_fft(&worker, &mut fft_kern)?;
+        c.ifft(&worker, &mut fft_kern)?;
+        c.coset_fft(&worker, &mut fft_kern)?;
 
         a.mul_assign(&worker, &b);
         drop(b);
         a.sub_assign(&worker, &c);
         drop(c);
-        a.divide_by_z_on_coset(&worker, &mut fft_kern);
-        a.icoset_fft(&worker, &mut fft_kern);
+        a.divide_by_z_on_coset(&worker, &mut fft_kern)?;
+        a.icoset_fft(&worker, &mut fft_kern)?;
         let mut a = a.into_coeffs();
         let a_len = a.len() - 1;
         a.truncate(a_len);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,13 +319,10 @@ pub enum SynthesisError {
     MalformedVerifyingKey,
     /// During CRS generation, we observed an unconstrained auxiliary variable
     UnconstrainedVariable,
-
     /// During GPU multiexp/fft, some GPU related error happened
-    #[cfg(feature = "gpu")]
     GPUError(gpu::GPUError),
 }
 
-#[cfg(feature = "gpu")]
 impl From<gpu::GPUError> for SynthesisError {
     fn from(e: gpu::GPUError) -> SynthesisError {
         SynthesisError::GPUError(e)
@@ -351,8 +348,6 @@ impl Error for SynthesisError {
             SynthesisError::IoError(_) => "encountered an I/O error",
             SynthesisError::MalformedVerifyingKey => "malformed verifying key",
             SynthesisError::UnconstrainedVariable => "auxiliary variable was unconstrained",
-
-            #[cfg(feature = "gpu")]
             SynthesisError::GPUError(_) => "encountered a GPU error",
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,17 @@ pub enum SynthesisError {
     MalformedVerifyingKey,
     /// During CRS generation, we observed an unconstrained auxiliary variable
     UnconstrainedVariable,
+
+    /// During GPU multiexp/fft, some GPU related error happened
+    #[cfg(feature = "gpu")]
+    GPUError(gpu::GPUError),
+}
+
+#[cfg(feature = "gpu")]
+impl From<gpu::GPUError> for SynthesisError {
+    fn from(e: gpu::GPUError) -> SynthesisError {
+        SynthesisError::GPUError(e)
+    }
 }
 
 impl From<io::Error> for SynthesisError {
@@ -340,6 +351,9 @@ impl Error for SynthesisError {
             SynthesisError::IoError(_) => "encountered an I/O error",
             SynthesisError::MalformedVerifyingKey => "malformed verifying key",
             SynthesisError::UnconstrainedVariable => "auxiliary variable was unconstrained",
+
+            #[cfg(feature = "gpu")]
+            SynthesisError::GPUError(_) => "encountered a GPU error",
         }
     }
 }

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -355,7 +355,7 @@ lazy_static::lazy_static! {
 }
 
 use std::env;
-pub fn gpu_multiexp_supported<E>(n: usize) -> gpu::GPUResult<gpu::MultiexpKernel<E>>
+pub fn gpu_multiexp_supported<E>(n: usize) -> Result<gpu::MultiexpKernel<E>, SynthesisError>
 where
     E: paired::Engine,
 {
@@ -399,11 +399,9 @@ where
                 exps.clone(),
                 &mut kern,
             )
-            .wait()
-            .unwrap();
+            .wait()?;
             let cpu_g1 = multiexp(&pool, (bases_g1, 0), FullDensity, exps.clone(), &mut None)
-                .wait()
-                .unwrap();
+                .wait()?;
             let gpu_g2 = multiexp(
                 &pool,
                 (bases_g2.clone(), 0),
@@ -411,11 +409,9 @@ where
                 exps.clone(),
                 &mut kern,
             )
-            .wait()
-            .unwrap();
+            .wait()?;
             let cpu_g2 = multiexp(&pool, (bases_g2, 0), FullDensity, exps, &mut None)
-                .wait()
-                .unwrap();
+                .wait()?;
             let res = cpu_g1 == gpu_g1 && cpu_g2 == gpu_g2;
             *supported = Some(res);
             res
@@ -424,9 +420,9 @@ where
     if res {
         Ok(kern.unwrap())
     } else {
-        Err(gpu::GPUError {
+        Err(SynthesisError::from(gpu::GPUError {
             msg: "GPU Multiexp not supported!".to_string(),
-        })
+        }))
     }
 }
 

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -286,7 +286,7 @@ where
 
         return Box::new(pool.compute(move || match result {
             Ok(p) => Ok(p),
-            Err(e) => Err(SynthesisError::from(e))
+            Err(e) => Err(SynthesisError::from(e)),
         }));
     }
 
@@ -400,8 +400,8 @@ where
                 &mut kern,
             )
             .wait()?;
-            let cpu_g1 = multiexp(&pool, (bases_g1, 0), FullDensity, exps.clone(), &mut None)
-                .wait()?;
+            let cpu_g1 =
+                multiexp(&pool, (bases_g1, 0), FullDensity, exps.clone(), &mut None).wait()?;
             let gpu_g2 = multiexp(
                 &pool,
                 (bases_g2.clone(), 0),
@@ -410,8 +410,7 @@ where
                 &mut kern,
             )
             .wait()?;
-            let cpu_g2 = multiexp(&pool, (bases_g2, 0), FullDensity, exps, &mut None)
-                .wait()?;
+            let cpu_g2 = multiexp(&pool, (bases_g2, 0), FullDensity, exps, &mut None).wait()?;
             let res = cpu_g1 == gpu_g1 && cpu_g2 == gpu_g2;
             *supported = Some(res);
             res

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -282,11 +282,12 @@ where
         }
 
         let (bss, skip) = bases.get();
-        let result = k
-            .multiexp(bss, Arc::new(exps), skip, n)
-            .expect("GPU Multiexp failed!");
+        let result = k.multiexp(bss, Arc::new(exps), skip, n);
 
-        return Box::new(pool.compute(move || Ok(result)));
+        return Box::new(pool.compute(move || match result {
+            Ok(p) => Ok(p),
+            Err(e) => Err(SynthesisError::from(e))
+        }));
     }
 
     let c = if exponents.len() < 32 {


### PR DESCRIPTION
You can now catch the `GPUError`s as a results of the `create_proof` function.