### PR TITLE
feat(gpu): cpu utilization for gpu multiexp 

### DIFF
--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -337,10 +337,7 @@ where
                     threads.push(s.spawn(
                         move |_| -> Result<<G as CurveAffine>::Projective, GPUError> {
                             let mut acc = <G as CurveAffine>::Projective::zero();
-                            for (bases, exps) in bases
-                                .chunks(kern.n)
-                                .zip(exps.chunks(kern.n))
-                            {
+                            for (bases, exps) in bases.chunks(kern.n).zip(exps.chunks(kern.n)) {
                                 let result = kern.multiexp(bases, exps, bases.len())?;
                                 acc.add_assign(&result);
                             }

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -274,7 +274,11 @@ where
                 msg: "No working GPUs found!".to_string(),
             });
         }
-        info!("Multiexp: {} working device(s) selected.", kernels.len());
+        info!(
+            "Multiexp: {} working device(s) selected. (CPU utilization: {})",
+            kernels.len(),
+            get_cpu_utilization()
+        );
         for (i, k) in kernels.iter().enumerate() {
             info!(
                 "Multiexp: Device {}: {} (Window-size: {}, Num-groups: {})",

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -9,7 +9,7 @@ use crossbeam::thread;
 use ff::{PrimeField, ScalarEngine};
 use futures::Future;
 use groupy::{CurveAffine, CurveProjective};
-use log::info;
+use log::{error, info};
 use ocl::{Buffer, Device, MemFlags, ProQue};
 use paired::Engine;
 use std::sync::Arc;
@@ -23,7 +23,13 @@ const MEMORY_PADDING: usize = 1 * 1024 * 1024 * 1024; // Consider 1GB of free me
 pub fn get_cpu_utilization() -> f64 {
     use std::env;
     env::var("BELLMAN_CPU_UTILIZATION")
-        .and_then(|v| Ok(v.parse().expect("Invalid BELLMAN_CPU_UTILIZATION!")))
+        .and_then(|v| match v.parse() {
+            Ok(val) => Ok(val),
+            Err(_) => {
+                error!("Invalid BELLMAN_CPU_UTILIZATION! Defaulting to 0...");
+                Ok(0f64)
+            }
+        })
         .unwrap_or(0f64)
         .max(0f64)
         .min(1f64)

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -18,7 +18,15 @@ use std::sync::Arc;
 
 const MAX_WINDOW_SIZE: usize = 10;
 const LOCAL_WORK_SIZE: usize = 256;
-const SPEEDUP: f64 = 3.1f64; // GeForce RTX 2080Ti over AMD Ryzen 7
+
+pub fn get_cpu_utilization() -> f64 {
+    use std::env;
+    env::var("BELLMAN_CPU_UTILIZATION")
+        .and_then(|v| Ok(v.parse().expect("Invalid BELLMAN_CPU_UTILIZATION!")))
+        .unwrap_or(0f64)
+        .max(0f64)
+        .min(1f64)
+}
 
 // Multiexp kernel for a single GPU
 pub struct SingleMultiexpKernel<E>
@@ -301,7 +309,7 @@ where
         let bases = &bases[skip..(skip + n)];
         let exps = &exps[..n];
 
-        let cpu_n = ((n as f64) / ((num_devices as f64) * SPEEDUP + 1f64)) as usize;
+        let cpu_n = ((n as f64) * get_cpu_utilization()) as usize;
         let n = n - cpu_n;
         let (cpu_bases, bases) = bases.split_at(cpu_n);
         let (cpu_exps, exps) = exps.split_at(cpu_n);

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -1,4 +1,5 @@
 use super::error::{GPUError, GPUResult};
+use crate::multicore::Worker;
 use ff::{PrimeField, ScalarEngine};
 use groupy::CurveAffine;
 use std::marker::PhantomData;
@@ -49,6 +50,7 @@ where
 
     pub fn multiexp<G>(
         &mut self,
+        _: &Worker,
         _: Arc<Vec<G>>,
         _: Arc<Vec<<<G::Engine as ScalarEngine>::Fr as PrimeField>::Repr>>,
         _: usize,

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -282,7 +282,7 @@ where
         }
 
         let (bss, skip) = bases.get();
-        let result = k.multiexp(bss, Arc::new(exps), skip, n);
+        let result = k.multiexp(pool, bss, Arc::new(exps), skip, n);
 
         return Box::new(pool.compute(move || match result {
             Ok(p) => Ok(p),

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -283,7 +283,7 @@ where
 
         let (bss, skip) = bases.get();
         let result = k
-            .multiexp(bss, Arc::new(exps), skip, n)
+            .multiexp(pool, bss, Arc::new(exps), skip, n)
             .expect("GPU Multiexp failed!");
 
         return Box::new(pool.compute(move || Ok(result)));


### PR DESCRIPTION
User can now choose what percent of the bases/exps he would like to be calculated on CPU through an environment variable called `BELLMAN_CPU_UTILIZATION`. Default value is 0 and user can set this to any value in the range of 0 and 1 (0 means all on GPU and 1 means all on CPU)
Best ratio can be found using trial and error.