### PR TITLE
feat(gpu): dynamic gpu parameters

### DIFF
--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -66,9 +66,10 @@ where
     E: Engine,
 {
     let aff_size = std::mem::size_of::<E::G1Affine>() + std::mem::size_of::<E::G2Affine>();
+    let exp_size = std::mem::size_of::<E::Fr>();
     let proj_size = std::mem::size_of::<E::G1>() + std::mem::size_of::<E::G2>();
     ((mem as usize) - MEMORY_PADDING - (2 * core_count * ((1 << MAX_WINDOW_SIZE) + 1) * proj_size))
-        / aff_size
+        / (aff_size + exp_size)
 }
 
 impl<E> SingleMultiexpKernel<E>

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -67,7 +67,7 @@ where
 {
     let aff_size = std::mem::size_of::<E::G1Affine>() + std::mem::size_of::<E::G2Affine>();
     let proj_size = std::mem::size_of::<E::G1>() + std::mem::size_of::<E::G2>();
-    ((mem as usize) - MEMORY_PADDING - (2 * core_count * (1 << MAX_WINDOW_SIZE + 1) * proj_size))
+    ((mem as usize) - MEMORY_PADDING - (2 * core_count * ((1 << MAX_WINDOW_SIZE) + 1) * proj_size))
         / aff_size
 }
 

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -279,11 +279,12 @@ where
         info!("Multiexp: {} working device(s) selected.", kernels.len());
         for (i, k) in kernels.iter().enumerate() {
             info!(
-                "Multiexp: Device {}: {} (Window-size: {}, Num-groups: {})",
+                "Multiexp: Device {}: {} (Window-size: {}, Num-groups: {}, Chunk-size: {})",
                 i,
                 k.proque.device().name()?,
                 k.window_size,
-                k.num_groups
+                k.num_groups,
+                k.n
             );
         }
         return Ok(MultiexpKernel::<E> { kernels });

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -41,7 +41,7 @@ impl<E> MultiexpKernel<E>
 where
     E: ScalarEngine,
 {
-    pub fn create(_: usize) -> GPUResult<MultiexpKernel<E>> {
+    pub fn create() -> GPUResult<MultiexpKernel<E>> {
         return Err(GPUError {
             msg: "GPU accelerator is not enabled!".to_string(),
         });

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -65,6 +65,15 @@ pub fn get_core_count(d: Device) -> GPUResult<usize> {
     }
 }
 
+pub fn get_memory(d: Device) -> GPUResult<u64> {
+    match d.info(ocl::enums::DeviceInfo::GlobalMemSize)? {
+        ocl::enums::DeviceInfoResult::GlobalMemSize(sz) => Ok(sz),
+        _ => Err(GPUError {
+            msg: "Cannot extract GPU memory!".to_string(),
+        }),
+    }
+}
+
 #[derive(Debug)]
 pub struct LockedFile(File);
 

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -247,7 +247,7 @@ where
         Arc::new(a.into_iter().map(|s| s.0.into_repr()).collect::<Vec<_>>())
     };
 
-    let mut multiexp_kern = gpu_multiexp_supported::<E>(n).ok();
+    let mut multiexp_kern = gpu_multiexp_supported::<E>().ok();
     if multiexp_kern.is_some() {
         info!("GPU Multiexp is supported!");
     } else {

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -354,16 +354,14 @@ lazy_static::lazy_static! {
 }
 
 use std::env;
-pub fn gpu_multiexp_supported<E>(n: usize) -> gpu::GPUResult<gpu::MultiexpKernel<E>>
+pub fn gpu_multiexp_supported<E>() -> gpu::GPUResult<gpu::MultiexpKernel<E>>
 where
     E: paired::Engine,
 {
     const TEST_SIZE: u32 = 1024;
-    const MAX_CHUNK_SIZE: usize = 8388608;
-    let chunk_size = std::cmp::min(MAX_CHUNK_SIZE, n);
     let pool = Worker::new();
     let rng = &mut rand::thread_rng();
-    let mut kern = Some(gpu::MultiexpKernel::<E>::create(chunk_size)?);
+    let mut kern = Some(gpu::MultiexpKernel::<E>::create()?);
 
     // Checking the correctness of GPU results can be time consuming. User can disable this
     // feature using BELLMAN_GPU_NO_CHECK flag.
@@ -438,7 +436,7 @@ pub fn gpu_multiexp_consistency() {
     const CHUNK_SIZE: usize = 1048576;
     const MAX_LOG_D: usize = 20;
     const START_LOG_D: usize = 10;
-    let mut kern = gpu::MultiexpKernel::<Bls12>::create(CHUNK_SIZE).ok();
+    let mut kern = gpu::MultiexpKernel::<Bls12>::create().ok();
     if kern.is_none() {
         panic!("Cannot initialize kernel!");
     }


### PR DESCRIPTION
Choose dynamic chunk-size for each card based on its memory instead of using a fixed one. This would allow the bellman library to support cards with smaller memories, and also use the full potential of cards with larger memories. It also makes the bellman library to choose the GPU parameters (num-windows/num-groups) per multiexp, instead of calculating a fixed one per kernel initialization.
This PR introduces a tiny performance increase of x1.03 for a 130mm circuit on a machine with x2 2080Tis. (362s vs 370s)