### PR TITLE
feat(gpu): better error logging

### DIFF
--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -68,7 +68,7 @@ where
     let aff_size = std::mem::size_of::<E::G1Affine>() + std::mem::size_of::<E::G2Affine>();
     let exp_size = std::mem::size_of::<E::Fr>();
     let proj_size = std::mem::size_of::<E::G1>() + std::mem::size_of::<E::G2>();
-    ((((mem as f64) * MEMORY_PADDING) as usize)
+    ((((mem as f64) * (1f64 - MEMORY_PADDING)) as usize)
         - (2 * core_count * ((1 << MAX_WINDOW_SIZE) + 1) * proj_size))
         / (aff_size + exp_size)
 }

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 const MAX_WINDOW_SIZE: usize = 10;
 const LOCAL_WORK_SIZE: usize = 256;
-const MEMORY_PADDING: usize = 1 * 1024 * 1024 * 1024; // Consider 1GB of free memory for the GPU
+const MEMORY_PADDING: f64 = 0.2f64; // Let 20% of GPU memory be free
 
 // Multiexp kernel for a single GPU
 pub struct SingleMultiexpKernel<E>
@@ -68,7 +68,8 @@ where
     let aff_size = std::mem::size_of::<E::G1Affine>() + std::mem::size_of::<E::G2Affine>();
     let exp_size = std::mem::size_of::<E::Fr>();
     let proj_size = std::mem::size_of::<E::G1>() + std::mem::size_of::<E::G2>();
-    ((mem as usize) - MEMORY_PADDING - (2 * core_count * ((1 << MAX_WINDOW_SIZE) + 1) * proj_size))
+    ((((mem as f64) * MEMORY_PADDING) as usize)
+        - (2 * core_count * ((1 << MAX_WINDOW_SIZE) + 1) * proj_size))
         / (aff_size + exp_size)
 }
 

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 const MAX_WINDOW_SIZE: usize = 10;
 const LOCAL_WORK_SIZE: usize = 256;
-const MEMORY_PADDING: f64 = 0.2f64; // Let 20% of GPU memory be free
+const MEMORY_PADDING: usize = 1 * 1024 * 1024 * 1024; // Consider 1GB of free memory for the GPU
 
 // Multiexp kernel for a single GPU
 pub struct SingleMultiexpKernel<E>
@@ -68,8 +68,7 @@ where
     let aff_size = std::mem::size_of::<E::G1Affine>() + std::mem::size_of::<E::G2Affine>();
     let exp_size = std::mem::size_of::<E::Fr>();
     let proj_size = std::mem::size_of::<E::G1>() + std::mem::size_of::<E::G2>();
-    ((((mem as f64) * MEMORY_PADDING) as usize)
-        - (2 * core_count * ((1 << MAX_WINDOW_SIZE) + 1) * proj_size))
+    ((mem as usize) - MEMORY_PADDING - (2 * core_count * ((1 << MAX_WINDOW_SIZE) + 1) * proj_size))
         / (aff_size + exp_size)
 }
 

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -68,7 +68,7 @@ where
     let aff_size = std::mem::size_of::<E::G1Affine>() + std::mem::size_of::<E::G2Affine>();
     let exp_size = std::mem::size_of::<E::Fr>();
     let proj_size = std::mem::size_of::<E::G1>() + std::mem::size_of::<E::G2>();
-    ((((mem as f64) * (1f64 - MEMORY_PADDING)) as usize)
+    ((((mem as f64) * MEMORY_PADDING) as usize)
         - (2 * core_count * ((1 << MAX_WINDOW_SIZE) + 1) * proj_size))
         / (aff_size + exp_size)
 }

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use ff::{Field, PrimeField};
 use futures::Future;
 use groupy::{CurveAffine, CurveProjective};
-use log::info;
+use log::{info, warn};
 use paired::Engine;
 
 use super::{ParameterSource, Proof};
@@ -216,12 +216,16 @@ where
     }
 
     let a = {
-        let mut fft_kern = gpu_fft_supported::<E>(log_d).ok();
-        if fft_kern.is_some() {
-            info!("GPU FFT is supported!");
-        } else {
-            info!("GPU FFT is NOT supported!");
-        }
+        let mut fft_kern = match gpu_fft_supported(log_d) {
+            Ok(k) => {
+                info!("GPU FFT is supported!");
+                Some(k)
+            }
+            Err(e) => {
+                warn!("GPU FFT not supported: error: {}", e);
+                None
+            }
+        };
 
         let mut a = EvaluationDomain::from_coeffs(prover.a)?;
         let mut b = EvaluationDomain::from_coeffs(prover.b)?;
@@ -247,12 +251,16 @@ where
         Arc::new(a.into_iter().map(|s| s.0.into_repr()).collect::<Vec<_>>())
     };
 
-    let mut multiexp_kern = gpu_multiexp_supported::<E>().ok();
-    if multiexp_kern.is_some() {
-        info!("GPU Multiexp is supported!");
-    } else {
-        info!("GPU Multiexp is NOT supported!");
-    }
+    let mut multiexp_kern = match gpu_multiexp_supported() {
+        Ok(k) => {
+            info!("GPU Multiexp is supported!");
+            Some(k)
+        }
+        Err(e) => {
+            warn!("GPU multiexp not supported: error: {}", e);
+            None
+        }
+    };
 
     let h = multiexp(
         &worker,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,9 @@ impl fmt::Display for SynthesisError {
         if let SynthesisError::IoError(ref e) = *self {
             write!(f, "I/O error: ")?;
             e.fmt(f)
+        } else if let SynthesisError::GPUError(ref e) = *self {
+            write!(f, "GPU error: ")?;
+            e.fmt(f)
         } else {
             write!(f, "{}", self.description())
         }


### PR DESCRIPTION
This PR contains better log messages about why kernels aren't instantiating. This way `multiexp NOT supported` isn't the only message logged when kernel instantiation fails. 