### PR TITLE
feat: add Circleci gpu config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,9 @@ jobs:
           command: cargo clippy --all-features
 
   build:
-    executor: default
+    machine:
+      resource_class: gpu.nvidia.medium
+      image: ubuntu-1604-cuda-10.1:201909-23
     steps:
       - *restore-workspace
       - *restore-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,6 @@ commands:
           name: Test (GPU) (<< parameters.target >>)
           command: TARGET=<< parameters.target >> cargo test --features gpu
           no_output_timeout: 15m
-      - run:
-          name: Build GPU (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo build --features gpu-test
-          no_output_timeout: 15m
 
 jobs:
   cargo_fetch:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ edition = "2018"
 [dependencies]
 bit-vec = "0.6"
 blake2s_simd = "0.5"
-ff = { version = "0.5.0" }
+ff = { version = "=0.5.0" }
 futures = "0.1"
 futures-cpupool = { version = "0.1", optional = true }
-groupy = { version = "0.2.0" }
+groupy = { version = "0.2.1" }
 num_cpus = { version = "1", optional = true }
 crossbeam = { version = "0.7", optional = true }
-paired = { version = "0.16", optional = true }
+paired = { version = "0.16.1", optional = true }
 rand_core = "0.5"
 byteorder = "1"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ sha2 = "0.8"
 [features]
 default = ["groth16", "multicore"]
 gpu = ["ocl", "itertools", "fs2"]
-gpu-test = ["gpu"]
 groth16 = ["paired"]
 multicore = ["futures-cpupool", "crossbeam", "num_cpus"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ documentation = "https://docs.rs/bellperson"
 homepage = "https://github.com/filecoin-project/bellman"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/filecoin-project/bellman"
-version = "0.5.2"
+version = "0.5.3"
 readme = "README.md"
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,61 @@
 and primitive structures, as well as basic gadget implementations such as
 booleans and number abstractions.
 
+## GPU
+
+This fork contains GPU parallel acceleration to the FFT and Multiexponentation algorithms in the groth16 prover codebase under a conditional compilation feature `#[cfg(feature = "gpu")]` and `gpu-test` for testing.
+
+### Environment variables
+
+The gpu extension contains some env vars that may be set externally to this library.
+
+#### BELLMAN_NO_GPU
+
+Will disable the GPU feature from the library and force usage of the CPU.
+```
+Example
+env::set_var("BELLMAN_NO_GPU", "1");
+```
+
+#### BELLMAN_GPU_NO_CHECK
+
+Checking the correctness of GPU results can be time consuming. User can disable this feature.
+```
+Example
+env::set_var("BELLMAN_GPU_NO_CHECK", "1");
+
+```
+
+#### BELLMAN_CUSTOM_GPU
+
+Will allow for adding a GPU not in the tested list. This requires researching the name of the GPU device and the number of cores in the format `["name:cores"]`.
+```
+Example
+env::set_var("BELLMAN_CUSTOM_GPU", "GeForce RTX 2080 Ti:4352, GeForce GTX 1060:1280");
+```
+
+#### BELLMAN_CPU_UTILIZATION
+
+Can be set in the interval [0,1] to designate a proportion of the multiexponenation calculation to be moved to cpu in parallel to the GPU to keep all hardware occupied. 
+
+```
+Example
+env::set_var("BELLMAN_CPU_UTILIZATION", "0.5");
+```
+
+#### Supported / Tested Cards
+
+Currently only Nvidia hardware is supported, see [issue](https://github.com/finalitylabs/bellman/issues/3). Depending on the size of the proof being passed to the gpu for work, certain cards will not be able to allocate enough memory to either the FFT or Multiexp kernel. Below are a list of devices that work for small sets. In the future we will add the cuttoff point at which a given card will not be able to allocate enough memory to utilize the GPU.
+
+```
+("GeForce RTX 2080 Ti".to_string(), 4352),
+("GeForce RTX 2080 SUPER".to_string(), 3072),
+("GeForce RTX 2080".to_string(), 2944),
+("GeForce GTX 1080 Ti".to_string(), 3584),
+("GeForce GTX 1080".to_string(), 2560),
+("GeForce GTX 1060".to_string(), 1280),
+```
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ booleans and number abstractions.
 
 This fork contains GPU parallel acceleration to the FFT and Multiexponentation algorithms in the groth16 prover codebase under a conditional compilation feature `#[cfg(feature = "gpu")]` and `gpu-test` for testing.
 
+### Requirements
+NVIDIA GPU Graphics Driver
+OpenCL
+
 ### Environment variables
 
 The gpu extension contains some env vars that may be set externally to this library.

--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ booleans and number abstractions.
 This fork contains GPU parallel acceleration to the FFT and Multiexponentation algorithms in the groth16 prover codebase under a conditional compilation feature `#[cfg(feature = "gpu")]` and `gpu-test` for testing.
 
 ### Requirements
-NVIDIA GPU Graphics Driver
-OpenCL
+- NVIDIA GPU Graphics Driver
+
+- OpenCL
 
 ### Environment variables
 
 The gpu extension contains some env vars that may be set externally to this library.
 
-#### BELLMAN_NO_GPU
+- #### BELLMAN_NO_GPU
 
 Will disable the GPU feature from the library and force usage of the CPU.
 ```
@@ -26,7 +27,7 @@ Example
 env::set_var("BELLMAN_NO_GPU", "1");
 ```
 
-#### BELLMAN_GPU_NO_CHECK
+- #### BELLMAN_GPU_NO_CHECK
 
 Checking the correctness of GPU results can be time consuming. User can disable this feature.
 ```
@@ -35,7 +36,7 @@ env::set_var("BELLMAN_GPU_NO_CHECK", "1");
 
 ```
 
-#### BELLMAN_CUSTOM_GPU
+- #### BELLMAN_CUSTOM_GPU
 
 Will allow for adding a GPU not in the tested list. This requires researching the name of the GPU device and the number of cores in the format `["name:cores"]`.
 ```
@@ -43,7 +44,7 @@ Example
 env::set_var("BELLMAN_CUSTOM_GPU", "GeForce RTX 2080 Ti:4352, GeForce GTX 1060:1280");
 ```
 
-#### BELLMAN_CPU_UTILIZATION
+- #### BELLMAN_CPU_UTILIZATION
 
 Can be set in the interval [0,1] to designate a proportion of the multiexponenation calculation to be moved to cpu in parallel to the GPU to keep all hardware occupied. 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This fork contains GPU parallel acceleration to the FFT and Multiexponentation a
 
 The gpu extension contains some env vars that may be set externally to this library.
 
-- #### BELLMAN_NO_GPU
+`BELLMAN_NO_GPU`
 
 Will disable the GPU feature from the library and force usage of the CPU.
 ```
@@ -27,7 +27,7 @@ Example
 env::set_var("BELLMAN_NO_GPU", "1");
 ```
 
-- #### BELLMAN_GPU_NO_CHECK
+`BELLMAN_GPU_NO_CHECK`
 
 Checking the correctness of GPU results can be time consuming. User can disable this feature.
 ```
@@ -36,7 +36,7 @@ env::set_var("BELLMAN_GPU_NO_CHECK", "1");
 
 ```
 
-- #### BELLMAN_CUSTOM_GPU
+`BELLMAN_CUSTOM_GPU`
 
 Will allow for adding a GPU not in the tested list. This requires researching the name of the GPU device and the number of cores in the format `["name:cores"]`.
 ```
@@ -44,7 +44,7 @@ Example
 env::set_var("BELLMAN_CUSTOM_GPU", "GeForce RTX 2080 Ti:4352, GeForce GTX 1060:1280");
 ```
 
-- #### BELLMAN_CPU_UTILIZATION
+`BELLMAN_CPU_UTILIZATION`
 
 Can be set in the interval [0,1] to designate a proportion of the multiexponenation calculation to be moved to cpu in parallel to the GPU to keep all hardware occupied. 
 
@@ -58,12 +58,13 @@ env::set_var("BELLMAN_CPU_UTILIZATION", "0.5");
 Currently only Nvidia hardware is supported, see [issue](https://github.com/finalitylabs/bellman/issues/3). Depending on the size of the proof being passed to the gpu for work, certain cards will not be able to allocate enough memory to either the FFT or Multiexp kernel. Below are a list of devices that work for small sets. In the future we will add the cuttoff point at which a given card will not be able to allocate enough memory to utilize the GPU.
 
 ```
-("GeForce RTX 2080 Ti".to_string(), 4352),
-("GeForce RTX 2080 SUPER".to_string(), 3072),
-("GeForce RTX 2080".to_string(), 2944),
-("GeForce GTX 1080 Ti".to_string(), 3584),
-("GeForce GTX 1080".to_string(), 2560),
-("GeForce GTX 1060".to_string(), 1280),
+("Device_Name", Cores),
+("GeForce RTX 2080 Ti", 4352),
+("GeForce RTX 2080 SUPER", 3072),
+("GeForce RTX 2080", 2944),
+("GeForce GTX 1080 Ti", 3584),
+("GeForce GTX 1080", 2560),
+("GeForce GTX 1060", 1280),
 ```
 
 ## License

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -626,7 +626,7 @@ where
     }
 }
 
-#[cfg(feature = "gpu-test")]
+#[cfg(feature = "gpu")]
 #[test]
 pub fn gpu_fft_consistency() {
     use paired::bls12_381::{Bls12, Fr};

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -423,7 +423,7 @@ where
     }
 }
 
-#[cfg(feature = "gpu-test")]
+#[cfg(feature = "gpu")]
 #[test]
 pub fn gpu_multiexp_consistency() {
     use paired::bls12_381::Bls12;


### PR DESCRIPTION
This also removes the gpu-test feature and requires that cirlceci machine builds with a supported nvidia gpu.