### PR TITLE
feat(gpu): drop kernels as soon as priority lock is seen 

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -295,7 +295,10 @@ fn best_fft<E: Engine, T: Group<E>>(
     log_n: u32,
 ) -> gpu::GPUResult<()> {
     if let Some(ref mut kern) = kern {
-        if let Ok(_) = kern.with(|k: &mut gpu::FFTKernel<E>| gpu_fft(k, a, omega, log_n)) {
+        if kern
+            .with(|k: &mut gpu::FFTKernel<E>| gpu_fft(k, a, omega, log_n))
+            .is_ok()
+        {
             return Ok(());
         }
     }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -295,13 +295,8 @@ fn best_fft<E: Engine, T: Group<E>>(
     log_n: u32,
 ) -> gpu::GPUResult<()> {
     if let Some(ref mut kern) = kern {
-        match kern.with(|k: &mut gpu::FFTKernel<E>| gpu_fft(k, a, omega, log_n)) {
-            Ok(_) => {
-                return Ok(());
-            }
-            Err(e) => {
-                warn!("GPU FFT failed! Falling back to CPU... Error: {}", e);
-            }
+        if let Ok(_) = kern.with(|k: &mut gpu::FFTKernel<E>| gpu_fft(k, a, omega, log_n)) {
+            return Ok(());
         }
     }
 

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -565,7 +565,7 @@ pub fn create_fft_kernel<E>(priority: bool) -> Option<gpu::FFTKernel<E>>
 where
     E: Engine,
 {
-    const N: u32 = 27;
+    const N: u32 = 1 << 27;
     match gpu::FFTKernel::create(N, priority) {
         Ok(k) => {
             info!("GPU FFT kernel instantiated!");

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -561,12 +561,11 @@ fn parallel_fft_consistency() {
     test_consistency::<Bls12, _>(rng);
 }
 
-pub fn create_fft_kernel<E>(priority: bool) -> Option<gpu::FFTKernel<E>>
+pub fn create_fft_kernel<E>(log_d: usize, priority: bool) -> Option<gpu::FFTKernel<E>>
 where
     E: Engine,
 {
-    const N: u32 = 1 << 27;
-    match gpu::FFTKernel::create(N, priority) {
+    match gpu::FFTKernel::create(1 << log_d, priority) {
         Ok(k) => {
             info!("GPU FFT kernel instantiated!");
             Some(k)

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -561,11 +561,12 @@ fn parallel_fft_consistency() {
     test_consistency::<Bls12, _>(rng);
 }
 
-pub fn create_fft_kernel<E>(log_d: u32, priority: bool) -> Option<gpu::FFTKernel<E>>
+pub fn create_fft_kernel<E>(priority: bool) -> Option<gpu::FFTKernel<E>>
 where
     E: Engine,
 {
-    match gpu::FFTKernel::create(1 << log_d, priority) {
+    const N : u32 = 27;
+    match gpu::FFTKernel::create(N, priority) {
         Ok(k) => {
             info!("GPU FFT kernel instantiated!");
             Some(k)

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -561,11 +561,11 @@ fn parallel_fft_consistency() {
     test_consistency::<Bls12, _>(rng);
 }
 
-pub fn create_fft_kernel<E>(log_d: u32) -> Option<gpu::FFTKernel<E>>
+pub fn create_fft_kernel<E>(log_d: u32, priority: bool) -> Option<gpu::FFTKernel<E>>
 where
     E: Engine,
 {
-    match gpu::FFTKernel::create(1 << log_d) {
+    match gpu::FFTKernel::create(1 << log_d, priority) {
         Ok(k) => {
             info!("GPU FFT kernel instantiated!");
             Some(k)
@@ -586,7 +586,7 @@ pub fn gpu_fft_consistency() {
 
     let worker = Worker::new();
     let log_cpus = worker.log_num_cpus();
-    let mut kern = gpu::FFTKernel::create(1 << 24).expect("Cannot initialize kernel!");
+    let mut kern = gpu::FFTKernel::create(1 << 24, false).expect("Cannot initialize kernel!");
 
     for log_d in 1..25 {
         let d = 1 << log_d;

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -565,7 +565,7 @@ pub fn create_fft_kernel<E>(priority: bool) -> Option<gpu::FFTKernel<E>>
 where
     E: Engine,
 {
-    const N : u32 = 27;
+    const N: u32 = 27;
     match gpu::FFTKernel::create(N, priority) {
         Ok(k) => {
             info!("GPU FFT kernel instantiated!");

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -295,7 +295,7 @@ fn best_fft<E: Engine, T: Group<E>>(
     log_n: u32,
 ) -> gpu::GPUResult<()> {
     if let Some(ref mut kern) = kern {
-        match kern.with(|k| gpu_fft(k, a, omega, log_n)) {
+        match kern.with(|k: &mut gpu::FFTKernel<E>| gpu_fft(k, a, omega, log_n)) {
             Ok(_) => {
                 return Ok(());
             }

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -8,6 +8,9 @@ pub enum GPUError {
     #[cfg(feature = "gpu")]
     #[error("GPU taken by a high priority process!")]
     GPUTaken,
+    #[cfg(feature = "gpu")]
+    #[error("No kernel is initialized!")]
+    KernelUninitialized,
 }
 
 pub type GPUResult<T> = std::result::Result<T, GPUError>;

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -2,21 +2,29 @@ use std::error;
 use std::fmt;
 
 #[derive(Debug, Clone)]
-pub struct GPUError {
-    pub msg: String,
+pub enum GPUError {
+    GPUTaken,
+    Msg(String),
 }
 
 pub type GPUResult<T> = std::result::Result<T, GPUError>;
 
 impl fmt::Display for GPUError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.msg)
+        if let GPUError::Msg(ref e) = *self {
+            e.fmt(f)
+        } else {
+            write!(f, "{}", self.to_string())
+        }
     }
 }
 
 impl error::Error for GPUError {
     fn description(&self) -> &str {
-        self.msg.as_str()
+        match *self {
+            GPUError::GPUTaken => "GPU taken by a high priority process!",
+            GPUError::Msg(_) => "GPU related error happened!",
+        }
     }
 
     fn cause(&self) -> Option<&dyn error::Error> {
@@ -30,9 +38,7 @@ use ocl;
 #[cfg(feature = "gpu")]
 impl From<ocl::Error> for GPUError {
     fn from(error: ocl::Error) -> Self {
-        GPUError {
-            msg: error.to_string(),
-        }
+        GPUError::Msg(error.to_string())
     }
 }
 
@@ -41,9 +47,7 @@ impl From<std::boxed::Box<dyn std::any::Any + std::marker::Send>> for GPUError {
     fn from(e: std::boxed::Box<dyn std::any::Any + std::marker::Send>) -> Self {
         match &e.downcast_ref::<Self>() {
             &Some(err) => err.clone(),
-            &None => GPUError {
-                msg: "An unknown GPU error happened!".to_string(),
-            },
+            &None => GPUError::Msg("An unknown GPU error happened!".to_string()),
         }
     }
 }

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -1,4 +1,3 @@
-use std::error;
 use std::fmt;
 
 #[derive(Debug, Clone)]
@@ -14,21 +13,8 @@ impl fmt::Display for GPUError {
         if let GPUError::Msg(ref e) = *self {
             e.fmt(f)
         } else {
-            write!(f, "{}", self.to_string())
+            write!(f, "GPU taken by a high priority process!")
         }
-    }
-}
-
-impl error::Error for GPUError {
-    fn description(&self) -> &str {
-        match *self {
-            GPUError::GPUTaken => "GPU taken by a high priority process!",
-            GPUError::Msg(_) => "GPU related error happened!",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
     }
 }
 

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -90,7 +90,6 @@ where
         max_deg: u32,
         in_src: bool,
     ) -> GPUResult<()> {
-
         if locks::PriorityLock::should_break(self.priority) {
             return Err(GPUError::GPUTaken);
         }

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -24,13 +24,14 @@ where
     fft_pq_buffer: Buffer<structs::PrimeFieldStruct<E::Fr>>,
     fft_omg_buffer: Buffer<structs::PrimeFieldStruct<E::Fr>>,
     _lock: locks::GPULock, // RFC 1857: struct fields are dropped in the same order as they are declared.
+    priority: bool,
 }
 
 impl<E> FFTKernel<E>
 where
     E: Engine,
 {
-    pub fn create(n: u32) -> GPUResult<FFTKernel<E>> {
+    pub fn create(n: u32, priority: bool) -> GPUResult<FFTKernel<E>> {
         let lock = locks::GPULock::lock();
 
         let src = sources::kernel::<E>();
@@ -72,6 +73,7 @@ where
             fft_pq_buffer: pqbuff,
             fft_omg_buffer: omgbuff,
             _lock: lock,
+            priority,
         })
     }
 

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -36,9 +36,7 @@ where
         let src = sources::kernel::<E>();
         let devices = &GPU_NVIDIA_DEVICES;
         if devices.is_empty() {
-            return Err(GPUError {
-                msg: "No working GPUs found!".to_string(),
-            });
+            return Err(GPUError::Msg("No working GPUs found!".to_string()));
         }
         let device = devices[0]; // Select the first device for FFT
         let pq = ProQue::builder().device(device).src(src).dims(n).build()?;

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -89,7 +89,12 @@ where
         deg: u32,
         max_deg: u32,
         in_src: bool,
-    ) -> ocl::Result<()> {
+    ) -> GPUResult<()> {
+
+        if locks::PriorityLock::should_break(self.priority) {
+            return Err(GPUError::GPUTaken);
+        }
+
         let n = 1u32 << lgn;
         let lwsd = cmp::min(deg - 1, MAX_LOCAL_WORK_SIZE_DEGREE);
         let kernel = self

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -108,8 +108,7 @@ macro_rules! locked_kernel {
                 }
 
                 if let Some(ref mut k) = self.kernel {
-                    let res = f(k);
-                    match res {
+                    match f(k) {
                         Err(e) => {
                             if let GPUError::GPUTaken = e {
                                 self.free();

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -114,7 +114,7 @@ macro_rules! locked_kernel {
                     }
                     res
                 } else {
-                    Err(GPUError::GPUTaken)
+                    Err(GPUError::KernelUninitialized)
                 }
             }
         }

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -69,7 +69,6 @@ where
     E: Engine,
 {
     priority: bool,
-    log_d: u32,
     kernel: Option<FFTKernel<E>>,
 }
 
@@ -77,10 +76,9 @@ impl<E> LockedFFTKernel<E>
 where
     E: Engine,
 {
-    pub fn new(priority: bool, log_d: u32) -> LockedFFTKernel<E> {
+    pub fn new(priority: bool) -> LockedFFTKernel<E> {
         LockedFFTKernel::<E> {
             priority,
-            log_d,
             kernel: None,
         }
     }
@@ -94,7 +92,7 @@ where
             self.free();
         } else if self.kernel.is_none() {
             info!("GPU is available!");
-            self.kernel = create_fft_kernel::<E>(self.log_d, self.priority);
+            self.kernel = create_fft_kernel::<E>(self.priority);
         }
         &mut self.kernel
     }

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -70,6 +70,7 @@ macro_rules! locked_kernel {
         where
             E: Engine,
         {
+            log_d: usize,
             priority: bool,
             kernel: Option<$kern<E>>,
         }
@@ -78,8 +79,9 @@ macro_rules! locked_kernel {
         where
             E: Engine,
         {
-            pub fn new(priority: bool) -> $class<E> {
+            pub fn new(log_d: usize, priority: bool) -> $class<E> {
                 $class::<E> {
+                    log_d,
                     priority,
                     kernel: None,
                 }
@@ -102,7 +104,7 @@ macro_rules! locked_kernel {
                     self.free();
                 } else if self.kernel.is_none() {
                     info!("GPU is available for {}!", $name);
-                    self.kernel = $func::<E>(self.priority);
+                    self.kernel = $func::<E>(self.log_d, self.priority);
                 }
 
                 if let Some(ref mut k) = self.kernel {

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -90,7 +90,7 @@ where
             }
         } else if self.kernel.is_none() {
             info!("GPU is available!");
-            self.kernel = create_fft_kernel::<E>(self.log_d);
+            self.kernel = create_fft_kernel::<E>(self.log_d, self.priority);
         }
         &mut self.kernel
     }
@@ -121,7 +121,7 @@ where
             }
         } else if self.kernel.is_none() {
             info!("GPU is available!");
-            self.kernel = create_multiexp_kernel::<E>();
+            self.kernel = create_multiexp_kernel::<E>(self.priority);
         }
         &mut self.kernel
     }

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -66,7 +66,6 @@ use paired::Engine;
 
 macro_rules! locked_kernel {
     ($class:ident, $kern:ident, $func:ident) => {
-
         pub struct $class<E>
         where
             E: Engine,
@@ -104,16 +103,11 @@ macro_rules! locked_kernel {
                 }
 
                 if let Some(ref mut k) = self.kernel {
-                    match f(k) {
-                        Ok(r) => Ok(r),
-                        Err(e) => match e {
-                            GPUError::GPUTaken => {
-                                self.free();
-                                Err(e)
-                            }
-                            _ => Err(e),
-                        },
+                    let res = f(k);
+                    if let Err(GPUError::GPUTaken) = res {
+                        self.free();
                     }
+                    res
                 } else {
                     Err(GPUError::GPUTaken)
                 }

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -187,6 +187,10 @@ where
     where
         G: CurveAffine,
     {
+        if locks::PriorityLock::should_break(self.priority) {
+            return Err(GPUError::GPUTaken);
+        }
+
         let exp_bits = std::mem::size_of::<E::Fr>() * 8;
         let window_size = calc_window_size(n as usize, exp_bits, self.core_count);
         let num_windows = ((exp_bits as f64) / (window_size as f64)).ceil() as usize;

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -55,6 +55,8 @@ where
 
     core_count: usize,
     n: usize,
+
+    priority: bool,
 }
 
 fn calc_num_groups(core_count: usize, num_windows: usize) -> usize {
@@ -107,7 +109,7 @@ impl<E> SingleMultiexpKernel<E>
 where
     E: Engine,
 {
-    pub fn create(d: Device) -> GPUResult<SingleMultiexpKernel<E>> {
+    pub fn create(d: Device, priority: bool) -> GPUResult<SingleMultiexpKernel<E>> {
         let src = sources::kernel::<E>();
         let pq = ProQue::builder().device(d).src(src).dims(1).build()?;
 
@@ -172,6 +174,7 @@ where
             exp_buffer: expbuff,
             core_count: core_count,
             n,
+            priority
         })
     }
 
@@ -295,12 +298,12 @@ impl<E> MultiexpKernel<E>
 where
     E: Engine,
 {
-    pub fn create() -> GPUResult<MultiexpKernel<E>> {
+    pub fn create(priority: bool) -> GPUResult<MultiexpKernel<E>> {
         let lock = locks::GPULock::lock();
 
         let kernels: Vec<_> = GPU_NVIDIA_DEVICES
             .iter()
-            .map(|d| SingleMultiexpKernel::<E>::create(*d))
+            .map(|d| SingleMultiexpKernel::<E>::create(*d, priority))
             .filter(|res| res.is_ok())
             .map(|res| res.unwrap())
             .collect();

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -174,7 +174,7 @@ where
             exp_buffer: expbuff,
             core_count: core_count,
             n,
-            priority
+            priority,
         })
     }
 

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -258,9 +258,9 @@ where
             };
             self.g2_result_buffer.read(tres).enq()?;
         } else {
-            return Err(GPUError {
-                msg: "Only E::G1 and E::G2 are supported!".to_string(),
-            });
+            return Err(GPUError::Msg(
+                "Only E::G1 and E::G2 are supported!".to_string(),
+            ));
         }
 
         // Using the algorithm below, we can calculate the final result by accumulating the results
@@ -305,9 +305,7 @@ where
             .map(|res| res.unwrap())
             .collect();
         if kernels.is_empty() {
-            return Err(GPUError {
-                msg: "No working GPUs found!".to_string(),
-            });
+            return Err(GPUError::Msg("No working GPUs found!".to_string()));
         }
         info!(
             "Multiexp: {} working device(s) selected. (CPU utilization: {})",

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -61,7 +61,7 @@ macro_rules! locked_kernel {
         where
             E: Engine,
         {
-            pub fn new(_: bool) -> $class<E> {
+            pub fn new(_: usize, _: bool) -> $class<E> {
                 $class::<E>(PhantomData)
             }
 

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -16,15 +16,11 @@ where
     E: ScalarEngine,
 {
     pub fn create(_: u32) -> GPUResult<FFTKernel<E>> {
-        return Err(GPUError {
-            msg: "GPU accelerator is not enabled!".to_string(),
-        });
+        return Err(GPUError::Msg("GPU accelerator is not enabled!".to_string()));
     }
 
     pub fn radix_fft(&mut self, _: &mut [E::Fr], _: &E::Fr, _: u32) -> GPUResult<()> {
-        return Err(GPUError {
-            msg: "GPU accelerator is not enabled!".to_string(),
-        });
+        return Err(GPUError::Msg("GPU accelerator is not enabled!".to_string()));
     }
 }
 
@@ -37,9 +33,7 @@ where
     E: ScalarEngine,
 {
     pub fn create() -> GPUResult<MultiexpKernel<E>> {
-        return Err(GPUError {
-            msg: "GPU accelerator is not enabled!".to_string(),
-        });
+        return Err(GPUError::Msg("GPU accelerator is not enabled!".to_string()));
     }
 
     pub fn multiexp<G>(
@@ -53,21 +47,46 @@ where
     where
         G: CurveAffine,
     {
-        return Err(GPUError {
-            msg: "GPU accelerator is not enabled!".to_string(),
-        });
+        return Err(GPUError::Msg("GPU accelerator is not enabled!".to_string()));
     }
 }
 
-pub struct LockedKernel<K> {
-    kernel: Option<K>,
+use paired::Engine;
+
+pub struct LockedFFTKernel<E>
+where
+    E: Engine,
+{
+    kernel: Option<FFTKernel<E>>,
 }
 
-impl<K> LockedKernel<K> {
-    pub fn new<F>(_: F, _: bool) -> LockedKernel<K> {
-        LockedKernel { kernel: None }
+impl<E> LockedFFTKernel<E>
+where
+    E: Engine,
+{
+    pub fn new(_: bool, _: u32) -> LockedFFTKernel<E> {
+        LockedFFTKernel::<E> { kernel: None }
     }
-    pub fn get(&mut self) -> &mut Option<K> {
+    pub fn get(&mut self) -> &mut Option<FFTKernel<E>> {
+        &mut self.kernel
+    }
+}
+
+pub struct LockedMultiexpKernel<E>
+where
+    E: Engine,
+{
+    kernel: Option<MultiexpKernel<E>>,
+}
+
+impl<E> LockedMultiexpKernel<E>
+where
+    E: Engine,
+{
+    pub fn new(_: bool) -> LockedMultiexpKernel<E> {
+        LockedMultiexpKernel::<E> { kernel: None }
+    }
+    pub fn get(&mut self) -> &mut Option<MultiexpKernel<E>> {
         &mut self.kernel
     }
 }

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -15,7 +15,7 @@ impl<E> FFTKernel<E>
 where
     E: ScalarEngine,
 {
-    pub fn create(_: u32) -> GPUResult<FFTKernel<E>> {
+    pub fn create(_: u32, _: bool) -> GPUResult<FFTKernel<E>> {
         return Err(GPUError::Msg("GPU accelerator is not enabled!".to_string()));
     }
 
@@ -32,7 +32,7 @@ impl<E> MultiexpKernel<E>
 where
     E: ScalarEngine,
 {
-    pub fn create() -> GPUResult<MultiexpKernel<E>> {
+    pub fn create(_: bool) -> GPUResult<MultiexpKernel<E>> {
         return Err(GPUError::Msg("GPU accelerator is not enabled!".to_string()));
     }
 

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -53,40 +53,27 @@ where
 
 use paired::Engine;
 
-pub struct LockedFFTKernel<E>
-where
-    E: Engine,
-{
-    kernel: Option<FFTKernel<E>>,
+macro_rules! locked_kernel {
+    ($class:ident) => {
+        pub struct $class<E>(PhantomData<E>);
+
+        impl<E> $class<E>
+        where
+            E: Engine,
+        {
+            pub fn new(_: bool) -> $class<E> {
+                $class::<E>(PhantomData)
+            }
+
+            pub fn with<F, R, K>(&mut self, _: F) -> GPUResult<R>
+            where
+                F: FnOnce(&mut K) -> GPUResult<R>,
+            {
+                return Err(GPUError::Msg("GPU accelerator is not enabled!".to_string()));
+            }
+        }
+    };
 }
 
-impl<E> LockedFFTKernel<E>
-where
-    E: Engine,
-{
-    pub fn new(_: bool, _: u32) -> LockedFFTKernel<E> {
-        LockedFFTKernel::<E> { kernel: None }
-    }
-    pub fn get(&mut self) -> &mut Option<FFTKernel<E>> {
-        &mut self.kernel
-    }
-}
-
-pub struct LockedMultiexpKernel<E>
-where
-    E: Engine,
-{
-    kernel: Option<MultiexpKernel<E>>,
-}
-
-impl<E> LockedMultiexpKernel<E>
-where
-    E: Engine,
-{
-    pub fn new(_: bool) -> LockedMultiexpKernel<E> {
-        LockedMultiexpKernel::<E> { kernel: None }
-    }
-    pub fn get(&mut self) -> &mut Option<MultiexpKernel<E>> {
-        &mut self.kernel
-    }
-}
+locked_kernel!(LockedFFTKernel);
+locked_kernel!(LockedMultiexpKernel);

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -10,9 +10,7 @@ pub const GPU_NVIDIA_PLATFORM_NAME: &str = "NVIDIA CUDA";
 
 pub fn get_devices(platform_name: &str) -> GPUResult<Vec<Device>> {
     if env::var("BELLMAN_NO_GPU").is_ok() {
-        return Err(GPUError {
-            msg: "GPU accelerator is disabled!".to_string(),
-        });
+        return Err(GPUError::Msg("GPU accelerator is disabled!".to_string()));
     }
 
     let platform = Platform::list()?.into_iter().find(|&p| match p.name() {
@@ -21,9 +19,7 @@ pub fn get_devices(platform_name: &str) -> GPUResult<Vec<Device>> {
     });
     match platform {
         Some(p) => Ok(Device::list_all(p)?),
-        None => Err(GPUError {
-            msg: "GPU platform not found!".to_string(),
-        }),
+        None => Err(GPUError::Msg("GPU platform not found!".to_string())),
     }
 }
 
@@ -69,17 +65,13 @@ lazy_static::lazy_static! {
 pub fn get_core_count(d: Device) -> GPUResult<usize> {
     match CORE_COUNTS.get(&d.name()?[..]) {
         Some(&cores) => Ok(cores),
-        None => Err(GPUError {
-            msg: "Device unknown!".to_string(),
-        }),
+        None => Err(GPUError::Msg("Device unknown!".to_string())),
     }
 }
 
 pub fn get_memory(d: Device) -> GPUResult<u64> {
     match d.info(ocl::enums::DeviceInfo::GlobalMemSize)? {
         ocl::enums::DeviceInfoResult::GlobalMemSize(sz) => Ok(sz),
-        _ => Err(GPUError {
-            msg: "Cannot extract GPU memory!".to_string(),
-        }),
+        _ => Err(GPUError::Msg("Cannot extract GPU memory!".to_string())),
     }
 }

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -231,6 +231,11 @@ where
         );
     }
 
+    let mut log_d = 0;
+    while (1 << log_d) < n {
+        log_d += 1;
+    }
+
     #[cfg(feature = "gpu")]
     let prio_lock = if priority {
         Some(PriorityLock::lock())
@@ -238,7 +243,7 @@ where
         None
     };
 
-    let mut fft_kern = Some(LockedFFTKernel::<E>::new(priority));
+    let mut fft_kern = Some(LockedFFTKernel::<E>::new(log_d, priority));
 
     let a_s = provers
         .iter_mut()
@@ -274,7 +279,7 @@ where
         .collect::<Result<Vec<_>, SynthesisError>>()?;
 
     drop(fft_kern);
-    let mut multiexp_kern = Some(LockedMultiexpKernel::<E>::new(priority));
+    let mut multiexp_kern = Some(LockedMultiexpKernel::<E>::new(log_d, priority));
 
     let h_s = a_s
         .into_iter()

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -231,11 +231,6 @@ where
         );
     }
 
-    let mut log_d = 0u32;
-    while (1 << log_d) < n {
-        log_d += 1;
-    }
-
     #[cfg(feature = "gpu")]
     let prio_lock = if priority {
         Some(PriorityLock::lock())
@@ -243,7 +238,7 @@ where
         None
     };
 
-    let mut fft_kern = Some(LockedFFTKernel::<E>::new(priority, log_d));
+    let mut fft_kern = Some(LockedFFTKernel::<E>::new(priority));
 
     let a_s = provers
         .iter_mut()

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -243,7 +243,7 @@ where
         None
     };
 
-    let mut fft_kern = LockedFFTKernel::<E>::new(priority, log_d);
+    let mut fft_kern = Some(LockedFFTKernel::<E>::new(priority, log_d));
 
     let a_s = provers
         .iter_mut()
@@ -255,19 +255,19 @@ where
             let mut c =
                 EvaluationDomain::from_coeffs(std::mem::replace(&mut prover.c, Vec::new()))?;
 
-            a.ifft(&worker, fft_kern.get())?;
-            a.coset_fft(&worker, fft_kern.get())?;
-            b.ifft(&worker, fft_kern.get())?;
-            b.coset_fft(&worker, fft_kern.get())?;
-            c.ifft(&worker, fft_kern.get())?;
-            c.coset_fft(&worker, fft_kern.get())?;
+            a.ifft(&worker, &mut fft_kern)?;
+            a.coset_fft(&worker, &mut fft_kern)?;
+            b.ifft(&worker, &mut fft_kern)?;
+            b.coset_fft(&worker, &mut fft_kern)?;
+            c.ifft(&worker, &mut fft_kern)?;
+            c.coset_fft(&worker, &mut fft_kern)?;
 
             a.mul_assign(&worker, &b);
             drop(b);
             a.sub_assign(&worker, &c);
             drop(c);
             a.divide_by_z_on_coset(&worker);
-            a.icoset_fft(&worker, fft_kern.get())?;
+            a.icoset_fft(&worker, &mut fft_kern)?;
             let mut a = a.into_coeffs();
             let a_len = a.len() - 1;
             a.truncate(a_len);
@@ -279,7 +279,7 @@ where
         .collect::<Result<Vec<_>, SynthesisError>>()?;
 
     drop(fft_kern);
-    let mut multiexp_kern = LockedMultiexpKernel::<E>::new(priority);
+    let mut multiexp_kern = Some(LockedMultiexpKernel::<E>::new(priority));
 
     let h_s = a_s
         .into_iter()
@@ -289,7 +289,7 @@ where
                 params.get_h(a.len())?,
                 FullDensity,
                 a,
-                multiexp_kern.get(),
+                &mut multiexp_kern,
             );
             Ok(h)
         })
@@ -329,7 +329,7 @@ where
                 params.get_l(aux_assignment.len())?,
                 FullDensity,
                 aux_assignment.clone(),
-                multiexp_kern.get(),
+                &mut multiexp_kern,
             );
             Ok(l)
         })
@@ -350,7 +350,7 @@ where
                 a_inputs_source,
                 FullDensity,
                 input_assignment.clone(),
-                multiexp_kern.get(),
+                &mut multiexp_kern,
             );
 
             let a_aux = multiexp(
@@ -358,7 +358,7 @@ where
                 a_aux_source,
                 Arc::new(prover.a_aux_density),
                 aux_assignment.clone(),
-                multiexp_kern.get(),
+                &mut multiexp_kern,
             );
 
             let b_input_density = Arc::new(prover.b_input_density);
@@ -374,14 +374,14 @@ where
                 b_g1_inputs_source,
                 b_input_density.clone(),
                 input_assignment.clone(),
-                multiexp_kern.get(),
+                &mut multiexp_kern,
             );
             let b_g1_aux = multiexp(
                 &worker,
                 b_g1_aux_source,
                 b_aux_density.clone(),
                 aux_assignment.clone(),
-                multiexp_kern.get(),
+                &mut multiexp_kern,
             );
 
             let (b_g2_inputs_source, b_g2_aux_source) =
@@ -392,14 +392,14 @@ where
                 b_g2_inputs_source,
                 b_input_density,
                 input_assignment.clone(),
-                multiexp_kern.get(),
+                &mut multiexp_kern,
             );
             let b_g2_aux = multiexp(
                 &worker,
                 b_g2_aux_source,
                 b_aux_density,
                 aux_assignment.clone(),
-                multiexp_kern.get(),
+                &mut multiexp_kern,
             );
 
             Ok((

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -273,7 +273,7 @@ where
     S: SourceBuilder<G>,
 {
     if let Some(ref mut kern) = kern {
-        match kern.with(|k: &mut gpu::MultiexpKernel<G::Engine>| {
+        if let Ok(p) = kern.with(|k: &mut gpu::MultiexpKernel<G::Engine>| {
             let mut exps = vec![exponents[0]; exponents.len()];
             let mut n = 0;
             for (&e, d) in exponents.iter().zip(density_map.as_ref().iter()) {
@@ -286,12 +286,7 @@ where
             let (bss, skip) = bases.clone().get();
             k.multiexp(pool, bss, Arc::new(exps.clone()), skip, n)
         }) {
-            Ok(p) => {
-                return Box::new(pool.compute(move || Ok(p)));
-            }
-            Err(e) => {
-                warn!("GPU Multiexp failed! Falling back to CPU... Error: {}", e);
-            }
+            return Box::new(pool.compute(move || Ok(p)));
         }
     }
 

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -365,7 +365,7 @@ fn test_with_bls12() {
     assert_eq!(naive, fast);
 }
 
-pub fn create_multiexp_kernel<E>(priority: bool) -> Option<gpu::MultiexpKernel<E>>
+pub fn create_multiexp_kernel<E>(_log_d: usize, priority: bool) -> Option<gpu::MultiexpKernel<E>>
 where
     E: paired::Engine,
 {
@@ -389,7 +389,7 @@ pub fn gpu_multiexp_consistency() {
 
     const MAX_LOG_D: usize = 20;
     const START_LOG_D: usize = 10;
-    let mut kern = Some(gpu::LockedMultiexpKernel::<Bls12>::new(false));
+    let mut kern = Some(gpu::LockedMultiexpKernel::<Bls12>::new(MAX_LOG_D, false));
     let pool = Worker::new();
 
     let rng = &mut rand::thread_rng();

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -363,11 +363,11 @@ fn test_with_bls12() {
     assert_eq!(naive, fast);
 }
 
-pub fn create_multiexp_kernel<E>() -> Option<gpu::MultiexpKernel<E>>
+pub fn create_multiexp_kernel<E>(priority: bool) -> Option<gpu::MultiexpKernel<E>>
 where
     E: paired::Engine,
 {
-    match gpu::MultiexpKernel::<E>::create() {
+    match gpu::MultiexpKernel::<E>::create(priority) {
         Ok(k) => {
             info!("GPU Multiexp kernel instantiated!");
             Some(k)
@@ -387,7 +387,7 @@ pub fn gpu_multiexp_consistency() {
 
     const MAX_LOG_D: usize = 20;
     const START_LOG_D: usize = 10;
-    let mut kern = gpu::MultiexpKernel::<Bls12>::create().ok();
+    let mut kern = gpu::MultiexpKernel::<Bls12>::create(false).ok();
     if kern.is_none() {
         panic!("Cannot initialize kernel!");
     }

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -273,7 +273,7 @@ where
     S: SourceBuilder<G>,
 {
     if let Some(ref mut kern) = kern {
-        match kern.with(|k| {
+        match kern.with(|k: &mut gpu::MultiexpKernel<G::Engine>| {
             let mut exps = vec![exponents[0]; exponents.len()];
             let mut n = 0;
             for (&e, d) in exponents.iter().zip(density_map.as_ref().iter()) {

--- a/tests/gpu_provers.rs
+++ b/tests/gpu_provers.rs
@@ -50,11 +50,10 @@ pub fn test_parallel_prover() {
         create_random_proof, create_random_proof_in_priority, generate_random_parameters,
         prepare_verifying_key, verify_proof,
     };
-    use log::info;
     use paired::bls12_381::Bls12;
     use rand::thread_rng;
     use std::thread;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     env_logger::init();
     let rng = &mut thread_rng();
@@ -78,23 +77,42 @@ pub fn test_parallel_prover() {
     let pvk = prepare_verifying_key(&params.vk);
     let pvk2 = prepare_verifying_key(&params2.vk);
 
-    let lower_thread = thread::spawn(move || {
-        info!("Creating proof from LOWER priority process...");
-        let rng = &mut thread_rng();
-        let proof_lower = create_random_proof(c2, &params2, rng).unwrap();
-        assert!(verify_proof(&pvk2, &proof_lower, &[]).unwrap());
-        info!("Proof Lower is verified!");
+    let higher_thread = thread::spawn(move || {
+        for _ in 0..10 {
+            let now = Instant::now();
+
+            let rng = &mut thread_rng();
+            let proof_higher = create_random_proof_in_priority(c.clone(), &params, rng).unwrap();
+            assert!(verify_proof(&pvk, &proof_higher, &[]).unwrap());
+
+            println!(
+                "Higher proof gen finished in {}s and {}ms",
+                now.elapsed().as_secs(),
+                now.elapsed().subsec_nanos() / 1000000
+            );
+
+            // Sleep in between higher proofs so that LOWER thread can acquire GPU again
+            thread::sleep(Duration::from_millis(3000));
+        }
     });
 
-    // Have higher prio proof wait long enough to interrupt lower
-    thread::sleep(Duration::from_millis(1500));
-
+    // Start lower proofs after a few seconds
+    thread::sleep(Duration::from_millis(10000));
+    println!("Starting low priority proof gen...");
     {
-        info!("Creating proof from HIGHER priority process...");
-        let proof_higher = create_random_proof_in_priority(c, &params, rng).unwrap();
-        assert!(verify_proof(&pvk, &proof_higher, &[]).unwrap());
-        info!("Proof Higher is verified!");
+        for _ in 0..10 {
+            let now = Instant::now();
+
+            let proof_lower = create_random_proof(c2.clone(), &params2, rng).unwrap();
+            assert!(verify_proof(&pvk2, &proof_lower, &[]).unwrap());
+
+            println!(
+                "Lower proof gen finished in {}s and {}ms",
+                now.elapsed().as_secs(),
+                now.elapsed().subsec_nanos() / 1000000
+            );
+        }
     }
 
-    lower_thread.join().unwrap();
+    higher_thread.join().unwrap();
 }

--- a/tests/gpu_provers.rs
+++ b/tests/gpu_provers.rs
@@ -8,12 +8,11 @@ use ff::{Field, PrimeField};
 use paired::Engine;
 
 #[derive(Clone)]
-pub struct DummyDemo<E: Engine> {
-    pub xx: Option<E::Fr>,
+pub struct DummyDemo {
     pub interations: u64,
 }
 
-impl<E: Engine> Circuit<E> for DummyDemo<E> {
+impl<E: Engine> Circuit<E> for DummyDemo {
     fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let mut x_val = E::Fr::from_str("2");
         let mut x = cs.alloc(|| "", || x_val.ok_or(SynthesisError::AssignmentMissing))?;
@@ -64,18 +63,16 @@ pub fn test_parallel_prover() {
     println!("Creating parameters...");
 
     // Higher prio circuit
-    let c = DummyDemo::<Bls12> {
-        xx: None,
+    let c = DummyDemo {
         interations: 10_000,
     };
     // Lower prio circuit
-    let c2 = DummyDemo::<Bls12> {
-        xx: None,
+    let c2 = DummyDemo {
         interations: 500_000,
     };
 
-    let params = generate_random_parameters(c.clone(), rng).unwrap();
-    let params2 = generate_random_parameters(c2.clone(), rng).unwrap();
+    let params = generate_random_parameters::<Bls12, _, _>(c.clone(), rng).unwrap();
+    let params2 = generate_random_parameters::<Bls12, _, _>(c2.clone(), rng).unwrap();
 
     // Prepare the verification key (for proof verification)
     let pvk = prepare_verifying_key(&params.vk);


### PR DESCRIPTION
Previously, kernels were only being dropped between full multiexp rounds, whereas the priority lock can be seen sooner (In between the full multiexp rounds)
This PR changes the structure of `GPUError`, adding a new `GPUTaken` kind of error, which is raised when priority lock is seen in chunked multiexp rounds, thus the gpu lock gets released sooner than before.