### PR TITLE
refactor: switch error handling to use thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ fs2 = { version = "0.4.3", optional = true }
 rand = "0.7"
 rayon = "1.3.0"
 memmap = "0.7.0"
+thiserror = "1.0.10"
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ blake2s_simd = "0.5"
 ff = { version = "0.2.0", package = "fff" }
 futures = "0.1"
 futures-cpupool = { version = "0.1", optional = true }
-groupy = "0.3.0"
+groupy = "0.3.1"
 num_cpus = { version = "1", optional = true }
 crossbeam = { version = "0.7", optional = true }
 paired = { version = "0.17.0", optional = true }

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -1,49 +1,27 @@
-use std::error;
-use std::fmt;
-
-#[derive(Debug, Clone)]
-pub struct GPUError {
-    pub msg: String,
+#[derive(thiserror::Error, Debug)]
+pub enum GPUError {
+    #[error("GPUError: {0}")]
+    Simple(&'static str),
+    #[cfg(feature = "gpu")]
+    #[error("Ocl Error: {0}")]
+    Ocl(ocl::Error),
 }
 
 pub type GPUResult<T> = std::result::Result<T, GPUError>;
 
-impl fmt::Display for GPUError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.msg)
-    }
-}
-
-impl error::Error for GPUError {
-    fn description(&self) -> &str {
-        self.msg.as_str()
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
-
-#[cfg(feature = "gpu")]
-use ocl;
-
 #[cfg(feature = "gpu")]
 impl From<ocl::Error> for GPUError {
     fn from(error: ocl::Error) -> Self {
-        GPUError {
-            msg: error.to_string(),
-        }
+        GPUError::Ocl(error)
     }
 }
 
 #[cfg(feature = "gpu")]
 impl From<std::boxed::Box<dyn std::any::Any + std::marker::Send>> for GPUError {
     fn from(e: std::boxed::Box<dyn std::any::Any + std::marker::Send>) -> Self {
-        match &e.downcast_ref::<Self>() {
-            &Some(err) => err.clone(),
-            &None => GPUError {
-                msg: "An unknown GPU error happened!".to_string(),
-            },
+        match e.downcast::<Self>() {
+            Ok(err) => *err,
+            Err(_) => GPUError::Simple("An unknown GPU error happened!"),
         }
     }
 }

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -36,9 +36,7 @@ where
         let src = sources::kernel::<E>();
         let devices = &GPU_NVIDIA_DEVICES;
         if devices.is_empty() {
-            return Err(GPUError {
-                msg: "No working GPUs found!".to_string(),
-            });
+            return Err(GPUError::Simple("No working GPUs found!"));
         }
         let device = devices[0]; // Select the first device for FFT
         let pq = ProQue::builder().device(device).src(src).dims(n).build()?;

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -258,9 +258,7 @@ where
             };
             self.g2_result_buffer.read(tres).enq()?;
         } else {
-            return Err(GPUError {
-                msg: "Only E::G1 and E::G2 are supported!".to_string(),
-            });
+            return Err(GPUError::Simple("Only E::G1 and E::G2 are supported!"));
         }
 
         // Using the algorithm below, we can calculate the final result by accumulating the results
@@ -305,9 +303,7 @@ where
             .map(|res| res.unwrap())
             .collect();
         if kernels.is_empty() {
-            return Err(GPUError {
-                msg: "No working GPUs found!".to_string(),
-            });
+            return Err(GPUError::Simple("No working GPUs found!"));
         }
         info!(
             "Multiexp: {} working device(s) selected. (CPU utilization: {})",

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -16,15 +16,11 @@ where
     E: ScalarEngine,
 {
     pub fn create(_: u32) -> GPUResult<FFTKernel<E>> {
-        return Err(GPUError {
-            msg: "GPU accelerator is not enabled!".to_string(),
-        });
+        return Err(GPUError::Simple("GPU accelerator is not enabled!"));
     }
 
     pub fn radix_fft(&mut self, _: &mut [E::Fr], _: &E::Fr, _: u32) -> GPUResult<()> {
-        return Err(GPUError {
-            msg: "GPU accelerator is not enabled!".to_string(),
-        });
+        return Err(GPUError::Simple("GPU accelerator is not enabled!"));
     }
 }
 
@@ -37,9 +33,7 @@ where
     E: ScalarEngine,
 {
     pub fn create() -> GPUResult<MultiexpKernel<E>> {
-        return Err(GPUError {
-            msg: "GPU accelerator is not enabled!".to_string(),
-        });
+        return Err(GPUError::Simple("GPU accelerator is not enabled!"));
     }
 
     pub fn multiexp<G>(
@@ -53,9 +47,7 @@ where
     where
         G: CurveAffine,
     {
-        return Err(GPUError {
-            msg: "GPU accelerator is not enabled!".to_string(),
-        });
+        return Err(GPUError::Simple("GPU accelerator is not enabled!"));
     }
 }
 

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -10,9 +10,7 @@ pub const GPU_NVIDIA_PLATFORM_NAME: &str = "NVIDIA CUDA";
 
 pub fn get_devices(platform_name: &str) -> GPUResult<Vec<Device>> {
     if env::var("BELLMAN_NO_GPU").is_ok() {
-        return Err(GPUError {
-            msg: "GPU accelerator is disabled!".to_string(),
-        });
+        return Err(GPUError::Simple("GPU accelerator is disabled!"));
     }
 
     let platform = Platform::list()?.into_iter().find(|&p| match p.name() {
@@ -21,9 +19,7 @@ pub fn get_devices(platform_name: &str) -> GPUResult<Vec<Device>> {
     });
     match platform {
         Some(p) => Ok(Device::list_all(p)?),
-        None => Err(GPUError {
-            msg: "GPU platform not found!".to_string(),
-        }),
+        None => Err(GPUError::Simple("GPU platform not found!")),
     }
 }
 
@@ -69,17 +65,13 @@ lazy_static::lazy_static! {
 pub fn get_core_count(d: Device) -> GPUResult<usize> {
     match CORE_COUNTS.get(&d.name()?[..]) {
         Some(&cores) => Ok(cores),
-        None => Err(GPUError {
-            msg: "Device unknown!".to_string(),
-        }),
+        None => Err(GPUError::Simple("Device unknown!")),
     }
 }
 
 pub fn get_memory(d: Device) -> GPUResult<u64> {
     match d.info(ocl::enums::DeviceInfo::GlobalMemSize)? {
         ocl::enums::DeviceInfoResult::GlobalMemSize(sz) => Ok(sz),
-        _ => Err(GPUError {
-            msg: "Cannot extract GPU memory!".to_string(),
-        }),
+        _ => Err(GPUError::Simple("Cannot extract GPU memory!")),
     }
 }


### PR DESCRIPTION
we had an accidental recursion in the manual implementation,
fixed now and switched to a library to avoid it in the future