### PR TITLE
Add extend ConstraintSystem method, implement for ProvingAssignment.

### DIFF
--- a/src/gadgets/test/mod.rs
+++ b/src/gadgets/test/mod.rs
@@ -132,22 +132,6 @@ fn eval_lc<E: ScalarEngine>(
 }
 
 impl<E: ScalarEngine> TestConstraintSystem<E> {
-    pub fn new() -> TestConstraintSystem<E> {
-        let mut map = HashMap::new();
-        map.insert(
-            "ONE".into(),
-            NamedObject::Var(TestConstraintSystem::<E>::one()),
-        );
-
-        TestConstraintSystem {
-            named_objects: map,
-            current_namespace: vec![],
-            constraints: vec![],
-            inputs: vec![(E::Fr::one(), "ONE".into())],
-            aux: vec![],
-        }
-    }
-
     pub fn pretty_print(&self) -> String {
         let mut s = String::new();
 
@@ -347,6 +331,22 @@ fn compute_path(ns: &[String], this: String) -> String {
 
 impl<E: ScalarEngine> ConstraintSystem<E> for TestConstraintSystem<E> {
     type Root = Self;
+
+    fn new() -> TestConstraintSystem<E> {
+        let mut map = HashMap::new();
+        map.insert(
+            "ONE".into(),
+            NamedObject::Var(TestConstraintSystem::<E>::one()),
+        );
+
+        TestConstraintSystem {
+            named_objects: map,
+            current_namespace: vec![],
+            constraints: vec![],
+            inputs: vec![(E::Fr::one(), "ONE".into())],
+            aux: vec![],
+        }
+    }
 
     fn alloc<F, A, AR>(&mut self, annotation: A, f: F) -> Result<Variable, SynthesisError>
     where

--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -53,6 +53,30 @@ struct KeypairAssembly<E: Engine> {
 impl<E: Engine> ConstraintSystem<E> for KeypairAssembly<E> {
     type Root = Self;
 
+    fn new() -> Self {
+        KeypairAssembly {
+            num_inputs: 0,
+            num_aux: 0,
+            num_constraints: 0,
+            at_inputs: vec![],
+            bt_inputs: vec![],
+            ct_inputs: vec![],
+            at_aux: vec![],
+            bt_aux: vec![],
+            ct_aux: vec![],
+        }
+    }
+
+    /// Explicitly declare this `ConstraintSystem` is not extensible as a reminder to future implementers.
+    /// By forbidding use of `ConstraintSystem::extend` when generating Groth parameters, we enforce
+    /// the requirement of a well-defined sequential circuit synthesis. This also means we know that any
+    /// synthesized `ProvingAssignment` is well-formed if it leads to a verifiable proof using the resulting
+    /// groth parameters and verifying key. This is true even if the `ProvingAssignment` was synthesized
+    /// in parallel components which were then joined by `ConstraintSystem::extend`.
+    fn is_extensible() -> bool {
+        false
+    }
+
     fn alloc<F, A, AR>(&mut self, _: A, _: F) -> Result<Variable, SynthesisError>
     where
         F: FnOnce() -> Result<E::Fr, SynthesisError>,
@@ -167,17 +191,7 @@ where
     E: Engine,
     C: Circuit<E>,
 {
-    let mut assembly = KeypairAssembly {
-        num_inputs: 0,
-        num_aux: 0,
-        num_constraints: 0,
-        at_inputs: vec![],
-        bt_inputs: vec![],
-        ct_inputs: vec![],
-        at_aux: vec![],
-        bt_aux: vec![],
-        ct_aux: vec![],
-    };
+    let mut assembly = KeypairAssembly::new();
 
     // Allocate the "one" input variable
     assembly.alloc_input(|| "", || Ok(E::Fr::one()))?;

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -73,12 +73,62 @@ struct ProvingAssignment<E: Engine> {
     input_assignment: Vec<E::Fr>,
     aux_assignment: Vec<E::Fr>,
 }
+use std::fmt;
+
+impl<E: Engine> fmt::Debug for ProvingAssignment<E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("ProvingAssignment")
+            .field("a_aux_density", &self.a_aux_density)
+            .field("b_input_density", &self.b_input_density)
+            .field("b_aux_density", &self.b_aux_density)
+            .field(
+                "a",
+                &self
+                    .a
+                    .iter()
+                    .map(|v| format!("Fr({:?})", v.0))
+                    .collect::<Vec<_>>(),
+            )
+            .field(
+                "b",
+                &self
+                    .b
+                    .iter()
+                    .map(|v| format!("Fr({:?})", v.0))
+                    .collect::<Vec<_>>(),
+            )
+            .field(
+                "c",
+                &self
+                    .c
+                    .iter()
+                    .map(|v| format!("Fr({:?})", v.0))
+                    .collect::<Vec<_>>(),
+            )
+            .field("input_assignment", &self.input_assignment)
+            .field("aux_assignment", &self.aux_assignment)
+            .finish()
+    }
+}
+
+impl<E: Engine> PartialEq for ProvingAssignment<E> {
+    fn eq(&self, other: &ProvingAssignment<E>) -> bool {
+        self.a_aux_density == other.a_aux_density
+            && self.b_input_density == other.b_input_density
+            && self.b_aux_density == other.b_aux_density
+            && self.a == other.a
+            && self.b == other.b
+            && self.c == other.c
+            && self.input_assignment == other.input_assignment
+            && self.aux_assignment == other.aux_assignment
+    }
+}
 
 impl<E: Engine> ConstraintSystem<E> for ProvingAssignment<E> {
     type Root = Self;
 
     fn new() -> Self {
-        ProvingAssignment {
+        Self {
             a_aux_density: DensityTracker::new(),
             b_input_density: DensityTracker::new(),
             b_aux_density: DensityTracker::new(),
@@ -177,20 +227,19 @@ impl<E: Engine> ConstraintSystem<E> for ProvingAssignment<E> {
         true
     }
 
-    fn extend(&mut self, other: &mut Self) {
-        self.a_aux_density.extend(&mut other.a_aux_density, false);
-        self.b_input_density
-            .extend(&mut other.b_input_density, true);
-        self.b_aux_density.extend(&mut other.b_aux_density, false);
+    fn extend(&mut self, other: Self) {
+        self.a_aux_density.extend(other.a_aux_density, false);
+        self.b_input_density.extend(other.b_input_density, true);
+        self.b_aux_density.extend(other.b_aux_density, false);
 
-        self.a.extend(other.a.clone());
-        self.b.extend(other.b.clone());
-        self.c.extend(other.c.clone());
+        self.a.extend(other.a);
+        self.b.extend(other.b);
+        self.c.extend(other.c);
 
         self.input_assignment
             // Skip first input, which must have been a temporarily allocated one variable.
-            .extend(&other.input_assignment.clone()[1..]);
-        self.aux_assignment.extend(other.aux_assignment.clone());
+            .extend(&other.input_assignment[1..]);
+        self.aux_assignment.extend(other.aux_assignment);
     }
 }
 
@@ -514,4 +563,75 @@ where
         .collect::<Result<Vec<_>, SynthesisError>>()?;
 
     Ok(proofs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use paired::bls12_381::{Bls12, Fr};
+    use rand::Rng;
+    use rand_core::SeedableRng;
+    use rand_xorshift::XorShiftRng;
+
+    #[test]
+    fn test_proving_assignment_extend() {
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+            0xbc, 0xe5,
+        ]);
+
+        for k in &[2, 4, 8] {
+            for j in &[10, 20, 50] {
+                let count: usize = k * j;
+
+                let mut full_assignment = ProvingAssignment::<Bls12>::new();
+                full_assignment
+                    .alloc_input(|| "one", || Ok(Fr::one()))
+                    .unwrap();
+
+                let mut partial_assignments = Vec::with_capacity(count / k);
+                for i in 0..count {
+                    if i % k == 0 {
+                        let mut p = ProvingAssignment::new();
+                        p.alloc_input(|| "one", || Ok(Fr::one())).unwrap();
+                        partial_assignments.push(p)
+                    }
+
+                    let index: usize = i / k;
+                    let partial_assignment = &mut partial_assignments[index];
+
+                    if rng.gen() {
+                        let el = Fr::random(&mut rng);
+                        full_assignment
+                            .alloc(|| format!("alloc:{},{}", i, k), || Ok(el.clone()))
+                            .unwrap();
+                        partial_assignment
+                            .alloc(|| format!("alloc:{},{}", i, k), || Ok(el))
+                            .unwrap();
+                    }
+
+                    if rng.gen() {
+                        let el = Fr::random(&mut rng);
+                        full_assignment
+                            .alloc_input(|| format!("alloc_input:{},{}", i, k), || Ok(el.clone()))
+                            .unwrap();
+                        partial_assignment
+                            .alloc_input(|| format!("alloc_input:{},{}", i, k), || Ok(el))
+                            .unwrap();
+                    }
+
+                    // TODO: LinearCombination
+                }
+
+                let mut combined = ProvingAssignment::new();
+                combined.alloc_input(|| "one", || Ok(Fr::one())).unwrap();
+
+                for assignment in partial_assignments.into_iter() {
+                    combined.extend(assignment);
+                }
+                assert_eq!(combined, full_assignment);
+            }
+        }
+    }
 }

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -111,6 +111,7 @@ impl<'a> QueryDensity for &'a FullDensity {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DensityTracker {
     pub bv: BitVec,
     pub total_density: usize,
@@ -153,34 +154,30 @@ impl DensityTracker {
 
     /// Extend by concatenating `other`. If `is_input_density` is true, then we are tracking an input density,
     /// and other may contain a redundant input for the `One` element. Coalesce those as needed and track the result.
-    pub fn extend(&mut self, other: &mut Self, is_input_density: bool) {
+    pub fn extend(&mut self, other: Self, is_input_density: bool) {
         self.total_density += other.total_density;
 
         if is_input_density {
             self.bv.pop();
 
-            let mut to_skip = 0;
-            if other.bv.len() > 0 && other.bv[0] {
+            let mut to_skip = false;
+            if !other.bv.is_empty() && other.bv[0] {
                 // If the bit is set for other's first input,
 
-                if self.bv.len() > 0 {
+                if !self.bv.is_empty() {
                     // Either set the bit for self's first input (if there is one),
                     self.bv.set(0, true);
                 } else {
                     // Or else add a bit so other's first input becomes self's first,
                     self.bv.push(true);
                     // And skip it so we only have a single One input (and it comes first).
-                    to_skip = 1;
+                    to_skip = true;
                 }
             }
 
-            other
-                .bv
-                .iter()
-                .skip(to_skip)
-                .for_each(|b| self.bv.push(b.clone()));
+            self.bv.extend(other.bv.iter().skip(to_skip as usize));
         } else {
-            self.bv.append(&mut other.bv);
+            self.bv.extend(other.bv);
         }
     }
 }
@@ -461,5 +458,59 @@ pub fn gpu_multiexp_consistency() {
         println!("============================");
 
         bases = [bases.clone(), bases.clone()].concat();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rand::Rng;
+    use rand_core::SeedableRng;
+    use rand_xorshift::XorShiftRng;
+
+    #[test]
+    fn test_extend_density_regular() {
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+            0xbc, 0xe5,
+        ]);
+
+        for k in &[2, 4, 8] {
+            for j in &[10, 20, 50] {
+                let count: usize = k * j;
+
+                let mut tracker_full = DensityTracker::new();
+                let mut partial_trackers: Vec<DensityTracker> = Vec::with_capacity(count / k);
+                for i in 0..count {
+                    if i % k == 0 {
+                        partial_trackers.push(DensityTracker::new());
+                    }
+
+                    let index: usize = i / k;
+                    if rng.gen() {
+                        tracker_full.add_element();
+                        partial_trackers[index].add_element();
+                    }
+
+                    if !partial_trackers[index].bv.is_empty() {
+                        let idx = rng.gen_range(0, partial_trackers[index].bv.len());
+                        let offset: usize = partial_trackers
+                            .iter()
+                            .take(index)
+                            .map(|t| t.bv.len())
+                            .sum();
+                        tracker_full.inc(offset + idx);
+                        partial_trackers[index].inc(idx);
+                    }
+                }
+
+                let mut tracker_combined = DensityTracker::new();
+                for tracker in partial_trackers.into_iter() {
+                    tracker_combined.extend(tracker, false);
+                }
+                assert_eq!(tracker_combined, tracker_full);
+            }
+        }
     }
 }

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -155,30 +155,27 @@ impl DensityTracker {
     /// Extend by concatenating `other`. If `is_input_density` is true, then we are tracking an input density,
     /// and other may contain a redundant input for the `One` element. Coalesce those as needed and track the result.
     pub fn extend(&mut self, other: Self, is_input_density: bool) {
-        self.total_density += other.total_density;
-
         if is_input_density {
-            self.bv.pop();
+            if !other.bv.is_empty() {
+                self.total_density -= (self.total_density > 0) as usize;
 
-            let mut to_skip = false;
-            if !other.bv.is_empty() && other.bv[0] {
-                // If the bit is set for other's first input,
-
-                if !self.bv.is_empty() {
-                    // Either set the bit for self's first input (if there is one),
-                    self.bv.set(0, true);
-                } else {
-                    // Or else add a bit so other's first input becomes self's first,
-                    self.bv.push(true);
-                    // And skip it so we only have a single One input (and it comes first).
-                    to_skip = true;
+                if other.bv[0] {
+                    // If the bit is set for other's first input,
+                    if !self.bv.is_empty() {
+                        // Either set the bit for self's first input (if there is one),
+                        self.bv.set(0, true);
+                    } else {
+                        // Or else add a bit so other's first input becomes self's first.
+                        self.bv.push(true);
+                    }
                 }
             }
 
-            self.bv.extend(other.bv.iter().skip(to_skip as usize));
+            self.bv.extend(other.bv.iter().skip(1));
         } else {
             self.bv.extend(other.bv);
         }
+        self.total_density += other.total_density;
     }
 }
 

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -157,10 +157,13 @@ impl DensityTracker {
     pub fn extend(&mut self, other: Self, is_input_density: bool) {
         if is_input_density {
             if !other.bv.is_empty() {
-                self.total_density -= (self.total_density > 0) as usize;
-
                 if other.bv[0] {
                     // If the bit is set for other's first input,
+
+                    let first_input_bit_set = !self.bv.is_empty() && self.bv[0];
+                    // If own first input is also set, decrement total density so the final total density sum doesn't overcount.
+                    self.total_density -= first_input_bit_set as usize;
+
                     if !self.bv.is_empty() {
                         // Either set the bit for self's first input (if there is one),
                         self.bv.set(0, true);


### PR DESCRIPTION
This PR adds a mechanism for concatenating independent constraint systems so circuit synthesis which can be performed in parallel — when the circuit in question can be decomposed to meet these constraints.

- [x] Add test(s?) -- NOTE: this is demonstrably working in downstream tests which rely on it, and comments in source here explain why I believe this is enough to ensure correctness. Nevertheless, it would be useful to demonstrate usage and correctness here as well. As a matter of expediency, it might prove easier to merge this PR first, so the downstream work can be finalized — then use that as the basis for a worked example here.