### PR TITLE
fix: multiexp avoid futures-cpu-pool and recursion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ edition = "2018"
 bit-vec = "0.6"
 blake2s_simd = "0.5"
 ff = { version = "0.2.0", package = "fff" }
-futures = "0.1"
-futures-cpupool = { version = "0.1", optional = true }
 groupy = "0.3.1"
 num_cpus = { version = "1", optional = true }
 paired = { version = "0.20.0", optional = true }
@@ -31,6 +29,7 @@ memmap = "0.7.0"
 thiserror = "1.0.10"
 ahash = "0.3.4"
 rust-gpu-tools = { version = "0.1.0", optional = true }
+crossbeam-channel = { version = "0.4.4", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.2"
@@ -43,7 +42,7 @@ criterion = "0.3.2"
 default = ["groth16", "multicore"]
 gpu = ["rust-gpu-tools", "ff-cl-gen", "fs2"]
 groth16 = ["paired"]
-multicore = ["futures-cpupool", "num_cpus"]
+multicore = ["crossbeam-channel", "num_cpus"]
 
 [[test]]
 name = "mimc"

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -5,7 +5,6 @@ use super::utils;
 use crate::multicore::Worker;
 use crate::multiexp::{multiexp as cpu_multiexp, FullDensity};
 use ff::{PrimeField, ScalarEngine};
-use futures::Future;
 use groupy::{CurveAffine, CurveProjective};
 use log::{error, info};
 use paired::Engine;

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use ff::{Field, PrimeField};
-use futures::Future;
 use groupy::{CurveAffine, CurveProjective};
 use paired::Engine;
 use rand_core::RngCore;

--- a/src/groth16/verifier.rs
+++ b/src/groth16/verifier.rs
@@ -1,5 +1,4 @@
 use ff::{Field, PrimeField};
-use futures::Future;
 use groupy::{CurveAffine, CurveProjective};
 use paired::{Engine, PairingCurveAffine};
 use rayon::prelude::*;

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -7,8 +7,7 @@
 
 #[cfg(feature = "multicore")]
 mod implementation {
-    use futures::{Future, IntoFuture, Poll};
-    use futures_cpupool::{CpuFuture, CpuPool};
+    use crossbeam_channel::{bounded, Receiver};
     use lazy_static::lazy_static;
     use num_cpus;
     use std::env;
@@ -27,7 +26,6 @@ mod implementation {
             .num_threads(*NUM_CPUS)
             .build()
             .unwrap();
-        static ref CPU_POOL: CpuPool = CpuPool::new(*NUM_CPUS);
     }
 
     #[derive(Clone)]
@@ -42,17 +40,18 @@ mod implementation {
             log2_floor(*NUM_CPUS)
         }
 
-        pub fn compute<F, R>(&self, f: F) -> WorkerFuture<R::Item, R::Error>
+        pub fn compute<F, R>(&self, f: F) -> Waiter<R>
         where
             F: FnOnce() -> R + Send + 'static,
-            R: IntoFuture + 'static,
-            R::Future: Send + 'static,
-            R::Item: Send + 'static,
-            R::Error: Send + 'static,
+            R: Send + 'static,
         {
-            WorkerFuture {
-                future: CPU_POOL.spawn_fn(f),
-            }
+            let (sender, receiver) = bounded(1);
+            THREAD_POOL.spawn(move || {
+                let res = f();
+                sender.send(res).unwrap();
+            });
+
+            Waiter { receiver }
         }
 
         pub fn scope<'a, F, R>(&self, elements: usize, f: F) -> R
@@ -70,16 +69,22 @@ mod implementation {
         }
     }
 
-    pub struct WorkerFuture<T, E> {
-        future: CpuFuture<T, E>,
+    pub struct Waiter<T> {
+        receiver: Receiver<T>,
     }
 
-    impl<T: Send + 'static, E: Send + 'static> Future for WorkerFuture<T, E> {
-        type Item = T;
-        type Error = E;
+    impl<T> Waiter<T> {
+        /// Wait for the result.
+        pub fn wait(&self) -> T {
+            self.receiver.recv().unwrap()
+        }
 
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            self.future.poll()
+        /// One off sending.
+        pub fn done(val: T) -> Self {
+            let (sender, receiver) = bounded(1);
+            sender.send(val).unwrap();
+
+            Waiter { receiver }
         }
     }
 
@@ -110,8 +115,6 @@ mod implementation {
 
 #[cfg(not(feature = "multicore"))]
 mod implementation {
-    use futures::{future, Future, IntoFuture, Poll};
-
     #[derive(Clone)]
     pub struct Worker;
 
@@ -124,15 +127,11 @@ mod implementation {
             0
         }
 
-        pub fn compute<F, R>(&self, f: F) -> R::Future
+        pub fn compute<F, R>(&self, f: F) -> Waiter<R>
         where
-            F: FnOnce() -> R + Send + 'static,
-            R: IntoFuture + 'static,
-            R::Future: Send + 'static,
-            R::Item: Send + 'static,
-            R::Error: Send + 'static,
+            R: Send + 'static,
         {
-            f().into_future()
+            Waiter::done(f())
         }
 
         pub fn scope<F, R>(&self, elements: usize, f: F) -> R
@@ -143,16 +142,19 @@ mod implementation {
         }
     }
 
-    pub struct WorkerFuture<T, E> {
-        future: future::FutureResult<T, E>,
+    pub struct Waiter<T> {
+        val: Option<T>,
     }
 
-    impl<T: Send + 'static, E: Send + 'static> Future for WorkerFuture<T, E> {
-        type Item = T;
-        type Error = E;
+    impl<T> Waiter<T> {
+        /// Wait for the result.
+        pub fn wait(&self) -> T {
+            self.val.take().unwrap()
+        }
 
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            self.future.poll()
+        /// One off sending.
+        pub fn done(val: T) -> Self {
+            Waiter { val }
         }
     }
 


### PR DESCRIPTION
The recursion triggered a deadlock sometimes, if the number of recursion steps was greater than the number of available threads. Perf tests for basics indicate no loss of performance