### PR TITLE
Minimally support Nova R1CS.

### DIFF
--- a/src/lc.rs
+++ b/src/lc.rs
@@ -6,7 +6,7 @@ use crate::multiexp::DensityTracker;
 
 /// Represents a variable in our constraint system.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Variable(pub(crate) Index);
+pub struct Variable(pub Index);
 
 impl Variable {
     /// This constructs a variable with an arbitrary index.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub mod util_cs;
 mod lc;
 pub use lc::{Index, LinearCombination, Variable};
 mod constraint_system;
-pub use constraint_system::{Circuit, ConstraintSystem, SynthesisError};
+pub use constraint_system::{Circuit, ConstraintSystem, Namespace, SynthesisError};
 
 pub const BELLMAN_VERSION: &str = env!("CARGO_PKG_VERSION");
 


### PR DESCRIPTION
This PR makes the minimal changes required for Nova to add [bellperson R1CS support](https://github.com/microsoft/Nova/pull/8) — along with some changes required to allow [Nova VDF proving](https://github.com/protocol/vdf/pull/9).

This will need to merge and be released before the [Nova PR](https://github.com/microsoft/Nova/pull/8) can be.